### PR TITLE
games: create endpoint with database-enforced idempotency

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,6 +27,13 @@ jobs:
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner
+      # The integration tests start apiservice on its https launch profile, so Kestrel needs a
+      # developer certificate. Runners have none; `certs trust` creates one if necessary.
+      # Version tracks the Aspire.Hosting.* packages and the AppHost SDK.
+      - name: Install Aspire CLI
+        run: dotnet tool install --global Aspire.Cli --version 13.4.6
+      - name: Trust HTTPS developer certificate
+        run: aspire certs trust --non-interactive
 
       - name: Start Sonar
         run: dotnet sonarscanner begin /k:"rombolshak_ahlcg_backend" /o:"rombolshak" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.coverageReportPaths=coveragereport/SonarQube.xml

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,6 +25,10 @@ jobs:
           dotnet-version: 10
       - name: Install coverage tool
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      # dotnet-coverage, not coverlet: the integration tests run the API in a process DCP
+      # spawns, which coverlet never instruments. See backend/coverage.runsettings.
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner
       # The integration tests start apiservice on its https launch profile, so Kestrel needs a
@@ -42,9 +46,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       - name: Test
-        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --logger:"trx"
+        run: dotnet-coverage collect --settings coverage.runsettings --output coverage.cobertura.xml --output-format cobertura -- dotnet test --no-build --verbosity normal --logger:"trx"
       - name: Create coverage report
-        run: reportgenerator -reports:"**/coverage.cobertura.xml" -targetDir:"coveragereport" -reporttypes:Html,cobertura,SonarQube -filefilters:"-*Generated*,-*Migrations/*,-*.g.cs" -classfilters:"-*Generated*"
+        run: reportgenerator -reports:"coverage.cobertura.xml" -targetDir:"coveragereport" -reporttypes:Html,cobertura,SonarQube -filefilters:"-*Generated*,-*Migrations/*,-*.g.cs" -classfilters:"-*Generated*"
       - name: Stop Sonar
         run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 

--- a/backend/Ahlcg.ApiService/ApplicationDbContext.cs
+++ b/backend/Ahlcg.ApiService/ApplicationDbContext.cs
@@ -1,7 +1,27 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Ahlcg.ApiService;
 
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-    : IdentityDbContext<AppUser>(options);
+    : IdentityDbContext<AppUser>(options)
+{
+    public DbSet<Game> Games => Set<Game>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder); // required — Identity's own model config lives here
+        builder.Entity<Game>(game =>
+        {
+            game.Property(g => g.Configuration)
+                .HasConversion(
+                    document => document.RootElement.GetRawText(),
+                    json => JsonDocument.Parse(json, default))
+                .HasColumnType("jsonb");
+            game.HasIndex(g => new { g.OwnerId, g.IdempotencyKey }).IsUnique();
+            game.HasOne(g => g.Owner).WithMany().HasForeignKey(g => g.OwnerId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/backend/Ahlcg.ApiService/GameEndpoints.cs
+++ b/backend/Ahlcg.ApiService/GameEndpoints.cs
@@ -1,0 +1,95 @@
+using System.Security.Claims;
+using System.Text.Json;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ahlcg.ApiService;
+
+public class Game
+{
+    public Guid Id { get; set; }
+    public required string OwnerId { get; set; }
+    public AppUser? Owner { get; set; }
+    public required string IdempotencyKey { get; set; }
+    public required JsonDocument Configuration { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset LastPlayedAt { get; set; }
+}
+
+public static class GameEndpoints
+{
+    [PublicAPI]
+    public record CreateGameRequest(JsonElement Configuration);
+
+    [PublicAPI]
+    public record GameDto(Guid Id, DateTimeOffset CreatedAt, DateTimeOffset LastPlayedAt, JsonElement Configuration);
+
+    public static RouteGroupBuilder MapGameEndpoints(this RouteGroupBuilder group)
+    {
+        group.WithDescription("Game creation and lifecycle.");
+
+        group.MapPost("", CreateGame)
+            .RequireAuthorization()
+            .WithDescription(
+                "Creates a new game owned by the calling user. " +
+                "The configuration payload is opaque and stored unchanged. " +
+                "Requires an Idempotency-Key header; repeating the same key for the same user " +
+                "returns the game created the first time instead of creating a new one.")
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    public static async Task<Results<Ok<GameDto>, ValidationProblem, UnauthorizedHttpResult>> CreateGame(
+        ClaimsPrincipal principal,
+        UserManager<AppUser> userManager,
+        ApplicationDbContext db,
+        TimeProvider timeProvider,
+        [FromHeader(Name = "Idempotency-Key")] string idempotencyKey,
+        CreateGameRequest request)
+    {
+        var user = await userManager.GetUserAsync(principal);
+        if (user is null) return TypedResults.Unauthorized();
+
+        if (request.Configuration.ValueKind == JsonValueKind.Undefined)
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                [nameof(CreateGameRequest.Configuration)] = ["Configuration is required."]
+            });
+
+        var now = timeProvider.GetUtcNow();
+        var game = new Game
+        {
+            OwnerId = user.Id,
+            IdempotencyKey = idempotencyKey,
+            Configuration = JsonDocument.Parse(request.Configuration.GetRawText()),
+            CreatedAt = now,
+            LastPlayedAt = now
+        };
+
+        db.Games.Add(game);
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            db.Entry(game).State = EntityState.Detached;
+
+            var existing =
+                await db.Games.FirstOrDefaultAsync(g => g.OwnerId == user.Id && g.IdempotencyKey == idempotencyKey);
+            if (existing is null) throw;
+
+            game = existing;
+        }
+
+        return TypedResults.Ok(new GameDto(
+            game.Id,
+            game.CreatedAt,
+            game.LastPlayedAt,
+            game.Configuration.RootElement.Clone()));
+    }
+}

--- a/backend/Ahlcg.ApiService/Migrations/20260806164122_Game_Add.Designer.cs
+++ b/backend/Ahlcg.ApiService/Migrations/20260806164122_Game_Add.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Ahlcg.ApiService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Ahlcg.ApiService.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806164122_Game_Add")]
+    partial class Game_Add
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Ahlcg.ApiService/Migrations/20260806164122_Game_Add.cs
+++ b/backend/Ahlcg.ApiService/Migrations/20260806164122_Game_Add.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ahlcg.ApiService.Migrations
+{
+    /// <inheritdoc />
+    public partial class Game_Add : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Games",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    IdempotencyKey = table.Column<string>(type: "text", nullable: false),
+                    Configuration = table.Column<string>(type: "jsonb", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastPlayedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Games", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Games_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Games_OwnerId_IdempotencyKey",
+                table: "Games",
+                columns: new[] { "OwnerId", "IdempotencyKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Games");
+        }
+    }
+}

--- a/backend/Ahlcg.ApiService/Program.cs
+++ b/backend/Ahlcg.ApiService/Program.cs
@@ -1,6 +1,7 @@
 using Ahlcg.ApiService;
 using Ahlcg.ServiceDefaults;
 using AspNetCore.SignalR.OpenTelemetry;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -14,6 +15,7 @@ builder.Services
     .AddValidation();
 
 builder.Services.AddSignalR().AddHubInstrumentation();
+builder.Services.TryAddSingleton(TimeProvider.System);
 
 builder.Services
     .AddIdentityApiEndpoints<AppUser>()
@@ -33,6 +35,7 @@ app.UseExceptionHandler().UseAuthentication().UseAuthorization();
 app.MapDefaultEndpoints();
 app.MapHub<GameHub>("/game");
 app.MapGroup("auth").MapAuthEndpoints().WithTags("Auth");
+app.MapGroup("games").MapGameEndpoints().WithTags("Games");
 
 if (app.Environment.IsDevelopment())
 {

--- a/backend/Ahlcg.AppHost/Ahlcg.AppHost.csproj
+++ b/backend/Ahlcg.AppHost/Ahlcg.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>

--- a/backend/Ahlcg.AppHost/AppHost.cs
+++ b/backend/Ahlcg.AppHost/AppHost.cs
@@ -13,7 +13,7 @@ var migrator =
 
 var apiService =
     builder
-        .AddProject<Ahlcg_ApiService>("apiservice")
+        .AddProject<Ahlcg_ApiService>("apiservice", launchProfileName: "https")
         .WithHttpHealthCheck("/health")
         .WithReference(database)
         .WithReference(migrator)

--- a/backend/Ahlcg.sln
+++ b/backend/Ahlcg.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ahlcg.AppHost", "Ahlcg.AppHost\Ahlcg.AppHost.csproj", "{E7E90ADE-C323-4465-871B-0DF80FE37892}"
 EndProject
@@ -11,6 +10,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ahlcg.ApiService.Tests", "unit-tests\Ahlcg.ApiService.Tests\Ahlcg.ApiService.Tests.csproj", "{00C31CFF-924B-4626-A46B-54CB17F530D5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{EF1B2283-59D3-4513-9247-C3A997A7FDB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ahlcg.ApiService.IntegrationTests", "integration-tests\Ahlcg.ApiService.IntegrationTests\Ahlcg.ApiService.IntegrationTests.csproj", "{3E6A7296-C982-464F-AD93-BDD1632AB6EF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IntegrationTests", "IntegrationTests", "{01662A60-E038-BA1A-0946-76A747E23EC8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,8 +41,13 @@ Global
 		{00C31CFF-924B-4626-A46B-54CB17F530D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00C31CFF-924B-4626-A46B-54CB17F530D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00C31CFF-924B-4626-A46B-54CB17F530D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E6A7296-C982-464F-AD93-BDD1632AB6EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E6A7296-C982-464F-AD93-BDD1632AB6EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E6A7296-C982-464F-AD93-BDD1632AB6EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E6A7296-C982-464F-AD93-BDD1632AB6EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{00C31CFF-924B-4626-A46B-54CB17F530D5} = {EF1B2283-59D3-4513-9247-C3A997A7FDB2}
+		{3E6A7296-C982-464F-AD93-BDD1632AB6EF} = {01662A60-E038-BA1A-0946-76A747E23EC8}
 	EndGlobalSection
 EndGlobal

--- a/backend/coverage.runsettings
+++ b/backend/coverage.runsettings
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Coverage settings for `dotnet-coverage collect`.
+
+  Why dotnet-coverage instead of coverlet ("XPlat Code Coverage"): the integration tests
+  exercise the API in a process DCP spawns, not in the test host. Coverlet only instruments the
+  test host, so it reported ~1.65% for Ahlcg.ApiService and left Program.cs and every Map*
+  method looking untested. dotnet-coverage instruments the whole process tree.
+
+  Two traps, both of which fail silently:
+
+  1. ModulePath patterns match the full path, not the file name. A pattern like
+     `.*Ahlcg\..*\.dll$` also matches every third-party assembly sitting in the Ahlcg.AppHost
+     output directory, so the filters must be anchored with `[\\/]` as below.
+  2. dotnet-coverage ignores a malformed settings file without any error, and coverage silently
+     widens to everything. XML comments cannot contain a double hyphen, which is easy to
+     introduce when pasting a CLI flag into a comment. If the report suddenly includes
+     Aspire.Hosting or HealthChecks packages, this file stopped parsing.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*[\\/]Ahlcg\.ApiService\.dll$</ModulePath>
+                <ModulePath>.*[\\/]Ahlcg\.ServiceDefaults\.dll$</ModulePath>
+              </Include>
+            </ModulePaths>
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/Ahlcg.ApiService.IntegrationTests.csproj
+++ b/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/Ahlcg.ApiService.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -9,10 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
         <PackageReference Include="coverlet.collector" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
-        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
     </ItemGroup>
@@ -22,7 +21,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\Ahlcg.ApiService\Ahlcg.ApiService.csproj" />
+        <ProjectReference Include="..\..\Ahlcg.AppHost\Ahlcg.AppHost.csproj" />
+        <ProjectReference Include="..\..\Ahlcg.ApiService\Ahlcg.ApiService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/AppFixture.cs
+++ b/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/AppFixture.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Postgres;
+using Aspire.Hosting.Testing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ahlcg.ApiService.IntegrationTests;
+
+/// <summary>
+/// Starts the real AppHost (Postgres, migrator, apiservice) once for the whole collection and
+/// drives it over real HTTP. The webfrontend (no Node in CI) and pgAdmin (dev convenience only)
+/// resources are removed before the app starts.
+/// </summary>
+public sealed class AppFixture : IAsyncLifetime
+{
+    private DistributedApplication _app = null!;
+    private Uri _apiBaseAddress = null!;
+
+    public string ConnectionString { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Ahlcg_AppHost>();
+
+        foreach (var resource in builder.Resources
+                     .Where(r => r.Name.StartsWith("webfrontend", StringComparison.Ordinal)
+                                 || r is PgAdminContainerResource)
+                     .ToList())
+        {
+            builder.Resources.Remove(resource);
+        }
+
+        _app = await builder.BuildAsync();
+        await _app.StartAsync();
+        await _app.ResourceNotifications.WaitForResourceHealthyAsync("apiservice");
+
+        _apiBaseAddress = _app.GetEndpoint("apiservice", "https");
+        ConnectionString = await _app.GetConnectionStringAsync("ahlcg")
+                            ?? throw new InvalidOperationException("No connection string for 'ahlcg'.");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _app.DisposeAsync();
+    }
+
+    /// <summary>
+    /// A fresh client with its own cookie jar, talking HTTPS to the real apiservice. Certificate
+    /// validation is disabled: the dev cert is trusted locally but never in CI, and the auth
+    /// cookie's Secure attribute means it cannot travel over plain HTTP instead.
+    /// </summary>
+    public HttpClient CreateClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            UseCookies = true,
+            CookieContainer = new CookieContainer(),
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        return new HttpClient(handler) { BaseAddress = _apiBaseAddress };
+    }
+
+    /// <summary>A fresh, untracked context against the real Postgres the app is running against.</summary>
+    public ApplicationDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class AppCollection : ICollectionFixture<AppFixture>
+{
+    public const string Name = "App";
+}

--- a/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/GameEndpointsTests.cs
+++ b/backend/integration-tests/Ahlcg.ApiService.IntegrationTests/GameEndpointsTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Ahlcg.ApiService;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ahlcg.ApiService.IntegrationTests;
+
+/// <summary>
+/// Drives POST /games over real HTTP against the real Aspire-orchestrated app and Postgres.
+/// EF's InMemory provider (used by the unit tests) does not enforce unique indexes, so the
+/// idempotency criteria can only be proven here.
+/// </summary>
+[Collection(AppCollection.Name)]
+public class GameEndpointsTests(AppFixture fixture)
+{
+    [Fact]
+    public async Task PostGames_WithoutCookie_ReturnsUnauthorized()
+    {
+        using var client = fixture.CreateClient();
+
+        var response = await PostGameAsync(client, "unauth-key", """{"foo":"bar"}""");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostGames_WithoutIdempotencyKeyHeader_ReturnsBadRequest()
+    {
+        using var client = fixture.CreateClient();
+        await LoginAnonymouslyAsync(client);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/games")
+        {
+            Content = JsonContent.Create(
+                new GameEndpoints.CreateGameRequest(ParseConfig("""{"foo":"bar"}""")),
+                options: JsonSerializerOptions.Web)
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostGames_Authenticated_CreatesGameOwnedByCaller()
+    {
+        using var client = fixture.CreateClient();
+        var userId = await LoginAnonymouslyAsync(client);
+
+        var response = await PostGameAsync(client, $"owner-{Guid.NewGuid()}", """{"foo":"bar"}""");
+        response.EnsureSuccessStatusCode();
+        var dto = await ReadGameAsync(response);
+
+        await using var db = fixture.CreateDbContext();
+        var stored = await db.Games.AsNoTracking().SingleAsync(g => g.Id == dto.Id);
+        Assert.Equal(userId, stored.OwnerId);
+    }
+
+    [Fact]
+    public async Task PostGames_SameKeyTwiceSameUser_ReturnsSameGameAndCreatesOneRow()
+    {
+        using var client = fixture.CreateClient();
+        await LoginAnonymouslyAsync(client);
+        var key = $"same-user-{Guid.NewGuid()}";
+
+        var first = await PostGameAsync(client, key, """{"a":1}""");
+        first.EnsureSuccessStatusCode();
+        var firstDto = await ReadGameAsync(first);
+
+        var second = await PostGameAsync(client, key, """{"a":1}""");
+        second.EnsureSuccessStatusCode();
+        var secondDto = await ReadGameAsync(second);
+
+        Assert.Equal(firstDto.Id, secondDto.Id);
+
+        await using var db = fixture.CreateDbContext();
+        var count = await db.Games.CountAsync(g => g.IdempotencyKey == key);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task PostGames_SameKeyDifferentUsers_CreatesTwoGames()
+    {
+        using var clientA = fixture.CreateClient();
+        using var clientB = fixture.CreateClient();
+        await LoginAnonymouslyAsync(clientA);
+        await LoginAnonymouslyAsync(clientB);
+        var key = $"shared-{Guid.NewGuid()}";
+
+        var responseA = await PostGameAsync(clientA, key, """{"a":1}""");
+        var responseB = await PostGameAsync(clientB, key, """{"a":1}""");
+        responseA.EnsureSuccessStatusCode();
+        responseB.EnsureSuccessStatusCode();
+
+        var dtoA = await ReadGameAsync(responseA);
+        var dtoB = await ReadGameAsync(responseB);
+
+        Assert.NotEqual(dtoA.Id, dtoB.Id);
+
+        await using var db = fixture.CreateDbContext();
+        var count = await db.Games.CountAsync(g => g.IdempotencyKey == key);
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task PostGames_Authenticated_ReturnsConfigurationUnchanged()
+    {
+        using var client = fixture.CreateClient();
+        await LoginAnonymouslyAsync(client);
+        const string json = """{"nested":{"array":[1,2,3]},"value":"hello"}""";
+
+        var response = await PostGameAsync(client, $"config-{Guid.NewGuid()}", json);
+        response.EnsureSuccessStatusCode();
+        var dto = await ReadGameAsync(response);
+
+        using var expected = JsonDocument.Parse(json);
+        Assert.True(JsonElement.DeepEquals(expected.RootElement, dto.Configuration));
+    }
+
+    [Fact]
+    public async Task OpenApi_DescribesPostGames()
+    {
+        using var client = fixture.CreateClient();
+
+        var response = await client.GetAsync("/openapi/v1.json");
+        response.EnsureSuccessStatusCode();
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var post = document.RootElement.GetProperty("paths").GetProperty("/games").GetProperty("post");
+
+        Assert.False(string.IsNullOrWhiteSpace(post.GetProperty("description").GetString()));
+    }
+
+    private static JsonElement ParseConfig(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static async Task<HttpResponseMessage> PostGameAsync(
+        HttpClient client, string idempotencyKey, string configurationJson)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/games")
+        {
+            Content = JsonContent.Create(
+                new GameEndpoints.CreateGameRequest(ParseConfig(configurationJson)),
+                options: JsonSerializerOptions.Web)
+        };
+        request.Headers.Add("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<GameEndpoints.GameDto> ReadGameAsync(HttpResponseMessage response)
+    {
+        var dto = await response.Content.ReadFromJsonAsync<GameEndpoints.GameDto>(JsonSerializerOptions.Web);
+        Assert.NotNull(dto);
+        return dto;
+    }
+
+    /// <summary>
+    /// Logs an anonymous session in on <paramref name="client"/> and returns the id of the user
+    /// that was created for it, found as the row that appeared in AspNetUsers as a side effect
+    /// of this call. Safe because the fixture's Postgres is exclusive to this test run and tests
+    /// in this class run sequentially (shared collection fixture).
+    /// </summary>
+    private async Task<string> LoginAnonymouslyAsync(HttpClient client)
+    {
+        await using var before = fixture.CreateDbContext();
+        var beforeIds = await before.Users.Select(u => u.Id).ToListAsync();
+
+        var response = await client.PostAsync("/auth/loginAnonymously", null);
+        response.EnsureSuccessStatusCode();
+
+        await using var after = fixture.CreateDbContext();
+        var afterIds = await after.Users.Select(u => u.Id).ToListAsync();
+
+        return afterIds.Except(beforeIds).Single();
+    }
+}

--- a/backend/unit-tests/Ahlcg.ApiService.Tests/GameEndpointsTests.cs
+++ b/backend/unit-tests/Ahlcg.ApiService.Tests/GameEndpointsTests.cs
@@ -1,0 +1,139 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Ahlcg.ApiService.Tests;
+
+public class GameEndpointsTests
+{
+    [Fact]
+    public async Task CreateGame_NotLoggedIn_ReturnsUnauthorized()
+    {
+        var userManager = GetMockUserManager();
+        await using var db = CreateInMemoryDb();
+
+        var result = await GameEndpoints.CreateGame(
+            NotAuthenticatedPrincipal,
+            userManager.Object,
+            db,
+            FixedTimeProvider,
+            "idempotency-key",
+            new GameEndpoints.CreateGameRequest(ParseConfiguration("""{"foo":"bar"}""")));
+
+        Assert.IsType<UnauthorizedHttpResult>(result.Result);
+        Assert.Empty(db.Games);
+    }
+
+    [Fact]
+    public async Task CreateGame_LoggedIn_PersistsGameOwnedByCaller()
+    {
+        var userManager = GetMockUserManager();
+        await using var db = CreateInMemoryDb();
+
+        var result = await GameEndpoints.CreateGame(
+            LoggedInPrincipal,
+            userManager.Object,
+            db,
+            FixedTimeProvider,
+            "idempotency-key",
+            new GameEndpoints.CreateGameRequest(ParseConfiguration("""{"foo":"bar"}""")));
+
+        var ok = Assert.IsType<Ok<GameEndpoints.GameDto>>(result.Result);
+        Assert.NotNull(ok.Value);
+
+        var stored = Assert.Single(db.Games);
+        Assert.Equal(LoggedInUser, stored.OwnerId);
+        Assert.Equal(ok.Value!.Id, stored.Id);
+        Assert.Equal(FixedNow, stored.CreatedAt);
+        Assert.Equal(FixedNow, stored.LastPlayedAt);
+    }
+
+    [Fact]
+    public async Task CreateGame_MissingConfiguration_ReturnsValidationProblem()
+    {
+        var userManager = GetMockUserManager();
+        await using var db = CreateInMemoryDb();
+
+        var result = await GameEndpoints.CreateGame(
+            LoggedInPrincipal,
+            userManager.Object,
+            db,
+            FixedTimeProvider,
+            "idempotency-key",
+            new GameEndpoints.CreateGameRequest(default));
+
+        Assert.IsType<ValidationProblem>(result.Result);
+        Assert.Empty(db.Games);
+    }
+
+    [Fact]
+    public async Task CreateGame_LoggedIn_ReturnsConfigurationUnchanged()
+    {
+        var userManager = GetMockUserManager();
+        await using var db = CreateInMemoryDb();
+        const string json = """{"nested":{"array":[1,2,3]},"value":"hello"}""";
+
+        var result = await GameEndpoints.CreateGame(
+            LoggedInPrincipal,
+            userManager.Object,
+            db,
+            FixedTimeProvider,
+            "idempotency-key",
+            new GameEndpoints.CreateGameRequest(ParseConfiguration(json)));
+
+        var ok = Assert.IsType<Ok<GameEndpoints.GameDto>>(result.Result);
+        using var expected = JsonDocument.Parse(json);
+        Assert.True(JsonElement.DeepEquals(expected.RootElement, ok.Value!.Configuration));
+    }
+
+    private static JsonElement ParseConfiguration(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static ApplicationDbContext CreateInMemoryDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static Mock<UserManager<AppUser>> GetMockUserManager()
+    {
+        var mock = new Mock<UserManager<AppUser>>(
+            new Mock<IUserStore<AppUser>>().Object,
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+        mock
+            .Setup(m => m.GetUserAsync(
+                It.Is<ClaimsPrincipal>(p => p.HasClaim(ClaimTypes.NameIdentifier, LoggedInUser))))
+            .ReturnsAsync(new AppUser { Id = LoggedInUser, UserName = Guid.NewGuid().ToString(), IsAnonymous = true });
+
+        return mock;
+    }
+
+    private const string LoggedInUser = "4139F1EA-4901-4253-A391-021FAA001677";
+
+    private static readonly ClaimsPrincipal NotAuthenticatedPrincipal = new(new ClaimsIdentity());
+
+    private static readonly ClaimsPrincipal LoggedInPrincipal =
+        new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, LoggedInUser)]));
+
+    private static readonly DateTimeOffset FixedNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly TimeProvider FixedTimeProvider = new FixedTimeProviderImpl();
+
+    private sealed class FixedTimeProviderImpl : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => FixedNow;
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Reference docs for agents working in this repository. Every claim here is checke
 
 ## Read this first
 
-The backend implements **authentication only**. The frontend game view renders from a **hardcoded fixture** (`@domain/test/test-game-state`), not from the server. There is no game API, no SignalR client, and no deployment pipeline. Do not write code that assumes any of them exist.
+The backend implements **authentication and game creation** (`POST /games`) — nothing more. The frontend game view renders from a **hardcoded fixture** (`@domain/test/test-game-state`), not from the server, and nothing in the frontend calls the games API. There is no API for game *state*, no SignalR client, and no deployment pipeline. Do not write code that assumes any of them exist.
 
 ## Which file do I need?
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,10 +1,10 @@
 # API Reference
 
-Source of truth: `backend/Ahlcg.ApiService/AuthEndpoints.cs` and `GameHub.cs`. Live spec in Development at `/openapi/v1.json`, browsable at `/scalar/v1`.
+Source of truth: `backend/Ahlcg.ApiService/AuthEndpoints.cs`, `GameEndpoints.cs`, and `GameHub.cs`. Live spec in Development at `/openapi/v1.json`, browsable at `/scalar/v1`.
 
-Base path is `/auth` (group registered as `app.MapGroup("auth")`, tagged `Auth`). From the frontend dev server the same routes are reached as `/api/auth/*` — see [architecture.md](architecture.md).
+Two route groups exist: `/auth` (`app.MapGroup("auth")`, tagged `Auth`) and `/games` (`app.MapGroup("games")`, tagged `Games`). From the frontend dev server the same routes are reached as `/api/auth/*` / `/api/games` — see [architecture.md](architecture.md).
 
-`AddIdentityApiEndpoints<AppUser>()` is called for its services, but `MapIdentityApi()` is **not** — the stock Identity routes (`/register`, `/login`, `/refresh`, `/confirmEmail`, …) do not exist. The four routes below are the entire API.
+`AddIdentityApiEndpoints<AppUser>()` is called for its services, but `MapIdentityApi()` is **not** — the stock Identity routes (`/register`, `/login`, `/refresh`, `/confirmEmail`, …) do not exist. The four `/auth` routes below plus `POST /games` are the entire API.
 
 ## POST /auth/loginAnonymously
 
@@ -47,9 +47,27 @@ Signs out. **Not** marked `RequireAuthorization`, so it is safe to call unauthen
 - `200 OK`, empty body. Clears the auth cookie.
 - Side effect: if the signed-in user has `IsAnonymous = true`, the account is deleted.
 
+## POST /games
+
+Creates a new game owned by the calling user. Requires authorization.
+
+Request headers:
+
+- `Idempotency-Key` — required. Repeating the same key for the same user returns the game created the first time instead of creating a second one; the same key from a *different* user creates a separate game. Enforced by a unique index on `(OwnerId, IdempotencyKey)` in the database, not by a check-then-insert.
+
+```json
+{ "configuration": { "...": "..." } }
+```
+
+`configuration` is opaque — the backend stores it in a `jsonb` column and hands it back unchanged, and never parses or validates its contents (#198). Only its *presence* is checked.
+
+- `200 OK` → `{ "id": "guid", "createdAt": "...", "lastPlayedAt": "...", "configuration": {...} }` (`GameDto`). `createdAt` and `lastPlayedAt` are equal on creation.
+- `400 Bad Request` (`ValidationProblem`) — the `configuration` field was omitted.
+- `401 Unauthorized` — no valid cookie.
+
 ## Error bodies
 
-Auth endpoints return `IdentityResult` (`{ succeeded, errors: [{ code, description }] }`) on `400`, **not** RFC 7807 ProblemDetails. `AddProblemDetails()` is registered and covers unhandled exceptions and framework-generated responses; do not assume a uniform error envelope across the API.
+Auth endpoints return `IdentityResult` (`{ succeeded, errors: [{ code, description }] }`) on `400`, **not** RFC 7807 ProblemDetails. `GameEndpoints.CreateGame` returns a `ValidationProblem` (RFC 7807) instead. `AddProblemDetails()` is registered and covers unhandled exceptions and framework-generated responses; do not assume a uniform error envelope across the API.
 
 ## SignalR: /game
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@
 | Auth (anonymous login, credential linking, logout, session info) | Implemented, backend + frontend |
 | Game view UI (board, investigator panel, cards, animations) | Implemented, driven by a local fixture |
 | Game state store with RFC6902 patching and arktype validation | Implemented, frontend only |
-| Game API / persistence of game state | **Does not exist** |
+| Game creation (`POST /games`) and persistence of the game record | Implemented, backend only — no frontend client calls it |
+| Game API / persistence of game *state* within a game | **Does not exist** |
 | SignalR | Server hub with a single `Ping()`; **no client** (`@microsoft/signalr` is not a dependency) |
 | Deployment | **Does not exist**. Aspire is local-dev orchestration only |
 
@@ -40,7 +41,7 @@ Aspire injects `services__apiservice__http__0` into the frontend process. `front
 | Animation | GSAP (+ Flip plugin) | Real-time | SignalR (`AspNetCore.SignalR.OpenTelemetry`) |
 | Styling | Tailwind CSS 4 + daisyUI 5 | Docs | OpenAPI + Scalar (dev only) |
 | i18n | Transloco | Telemetry | OpenTelemetry via `Ahlcg.ServiceDefaults` |
-| Tests | Vitest + happy-dom | Tests | xUnit + Moq + coverlet |
+| Tests | Vitest + happy-dom | Tests | xUnit + Moq + coverlet; Aspire.Hosting.Testing (integration) |
 | Components | Storybook 10 + Chromatic | Orchestration | .NET Aspire (dev only) |
 | Errors | Bugsnag | | |
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -6,21 +6,24 @@
 
 | Project | Role |
 | --- | --- |
-| `Ahlcg.ApiService` | The API. `Program.cs`, `AuthEndpoints.cs`, `GameHub.cs`, `ApplicationDbContext.cs`, `Migrations/` |
+| `Ahlcg.ApiService` | The API. `Program.cs`, `AuthEndpoints.cs`, `GameEndpoints.cs`, `GameHub.cs`, `ApplicationDbContext.cs`, `Migrations/` |
 | `Ahlcg.AppHost` | .NET Aspire orchestration for local dev (`AppHost.cs`) |
 | `Ahlcg.Migrator` | One-shot `BackgroundService` that applies migrations and stops the host |
 | `Ahlcg.ServiceDefaults` | Shared OpenTelemetry, health checks, and HTTP resilience (`Extensions.cs`) |
-| `unit-tests/Ahlcg.ApiService.Tests` | xUnit + Moq |
+| `unit-tests/Ahlcg.ApiService.Tests` | xUnit + Moq, handler-level, no database |
+| `integration-tests/Ahlcg.ApiService.IntegrationTests` | xUnit + Aspire.Hosting.Testing, drives the real API over real HTTP against real Postgres — see [testing.md](testing.md) |
 
 ## Startup
 
-`Program.cs` is short — read it rather than a summary. Order: `AddServiceDefaults()` → `AddNpgsqlDbContext<ApplicationDbContext>("ahlcg")` → problem details, OpenAPI, `AddValidation()` → SignalR with OTel hub instrumentation → Identity API endpoints + EF stores → cookie configuration. Then `UseExceptionHandler().UseAuthentication().UseAuthorization()`, `MapDefaultEndpoints()`, `MapHub<GameHub>("/game")`, `MapGroup("auth").MapAuthEndpoints()`. OpenAPI, Scalar, and the developer exception page are Development-only.
+`Program.cs` is short — read it rather than a summary. Order: `AddServiceDefaults()` → `AddNpgsqlDbContext<ApplicationDbContext>("ahlcg")` → problem details, OpenAPI, `AddValidation()` → SignalR with OTel hub instrumentation → `TryAddSingleton(TimeProvider.System)` → Identity API endpoints + EF stores → cookie configuration. Then `UseExceptionHandler().UseAuthentication().UseAuthorization()`, `MapDefaultEndpoints()`, `MapHub<GameHub>("/game")`, `MapGroup("auth").MapAuthEndpoints()`, `MapGroup("games").MapGameEndpoints()`. OpenAPI, Scalar, and the developer exception page are Development-only.
 
 The connection string name is `ahlcg`, supplied by Aspire.
 
+`Ahlcg.AppHost/AppHost.cs` adds `apiservice` with `launchProfileName: "https"` so it exposes the HTTPS endpoint its own `https` launch profile declares, in addition to the default `http` one. This is needed by the integration test project (see [testing.md](testing.md)) — the auth cookie is `Secure`, and `CookieContainer` will not send a `Secure` cookie over plain HTTP.
+
 ## Endpoints
 
-One route group per feature, defined as a static class with a `Map*Endpoints(this RouteGroupBuilder)` extension and static handler methods, registered from `Program.cs`. `AuthEndpoints.cs` is the only existing group and the pattern to copy:
+One route group per feature, defined as a static class with a `Map*Endpoints(this RouteGroupBuilder)` extension and static handler methods, registered from `Program.cs`. `AuthEndpoints.cs` and `GameEndpoints.cs` are the existing groups and the pattern to copy:
 
 - Handlers return `Results<TOk, TError…>` (typed results), not `IResult`. This is what makes them directly unit-testable — the tests call `AuthEndpoints.LoginAnonymously(principal, userManager, signInManager)` with mocks and assert on `result.Result`.
 - Dependencies (`ClaimsPrincipal`, `UserManager<AppUser>`, `SignInManager<AppUser>`, the request record) arrive as handler parameters.
@@ -36,7 +39,7 @@ There is no service layer, repository layer, or DTO folder. Do not invent one fo
 public class AppUser : IdentityUser { public bool IsAnonymous { get; set; } }
 ```
 
-Declared in `AuthEndpoints.cs`. `ApplicationDbContext` is `IdentityDbContext<AppUser>` with no additional entities or `OnModelCreating` overrides — the schema is stock Identity plus the `IsAnonymous` column.
+Declared in `AuthEndpoints.cs`. `ApplicationDbContext` is `IdentityDbContext<AppUser>` plus one additional entity, `Game` (declared in `GameEndpoints.cs`, the same way `AppUser` lives in `AuthEndpoints.cs`), and one `OnModelCreating` override that configures it: a unique index on `(OwnerId, IdempotencyKey)` and a cascade-delete foreign key to the owning `AppUser` (so a deleted anonymous user's games go with it, rather than orphaning the FK).
 
 Lifecycle: anonymous login creates a user with a GUID `UserName` and no password → `linkCredentials` either adds a password and sets email/username (`IsAnonymous = false`) or, if the email already exists, verifies the password, deletes the anonymous user, and signs in the existing one → logout deletes the user if still anonymous.
 
@@ -44,12 +47,19 @@ Lifecycle: anonymous login creates a user with a GUID `UserName` and no password
 
 Cookie settings (`ConfigureApplicationCookie`): 90-day expiry, sliding, `HttpOnly`, `SecurePolicy = Always`, `SameSite = Lax`. See [security.md](security.md).
 
+## Games
+
+`Game` (id, `OwnerId`, `IdempotencyKey`, `Configuration`, `CreatedAt`, `LastPlayedAt`) is the first game-shaped entity the backend stores. `Configuration` is a `JsonDocument`, mapped with an explicit `HasConversion` to a `jsonb` column — the conversion exists so the model also builds under EF's InMemory provider (used by the unit tests); without it, InMemory tries to treat `JsonDocument` as a navigable/owned entity and fails, since the automatic scalar mapping for `JsonDocument` is Npgsql-provider-specific. The backend never parses or validates `Configuration` (#198) — presence is checked, contents are not.
+
+`POST /games` (`GameEndpoints.CreateGame`) requires a client-supplied `Idempotency-Key` header. Repeating the same key for the same owner returns the game created the first time; enforced by the database unique index rather than a check-then-insert, which would race. The handler saves optimistically and, on `DbUpdateException`, re-reads by `(OwnerId, IdempotencyKey)` and returns that row instead — rethrowing if nothing is found, since that means the failure was something else.
+
 ## Persistence and migrations
 
 EF Core 10 with Npgsql, code-first. Migrations live in `Ahlcg.ApiService/Migrations/`:
 
 - `20251114145044_Initial` — Identity schema
 - `20251114153547_User_AddIsAnonymous` — the `IsAnonymous` column
+- `20260806164122_Game_Add` — the `Games` table
 
 Add one with `dotnet ef migrations add {Name}` from `backend/Ahlcg.ApiService`. Never hand-edit generated migrations or the model snapshot.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,7 +16,7 @@ options.Cookie.SameSite = SameSiteMode.Lax;
 
 `SecurePolicy = Always` means the cookie is only sent over HTTPS. The frontend never reads or handles the cookie; there is no token storage anywhere in the client.
 
-**Authorization** — opt-in per route via `.RequireAuthorization()`. `/auth/info` and `/auth/linkCredentials` require it; `/auth/loginAnonymously` and `/auth/logout` do not. `GameHub` is `[Authorize]`. There are no roles, policies, or claims checks — any authenticated user, anonymous or permanent, is treated identically.
+**Authorization** — opt-in per route via `.RequireAuthorization()`; read the endpoint definitions for which routes carry it. `GameHub` is `[Authorize]`. There are no roles, policies, or claims checks — any authenticated user, anonymous or permanent, is treated identically. Nothing checks ownership of a resource either: `Game.OwnerId` is recorded but not yet enforced anywhere.
 
 **Password handling** — entirely ASP.NET Identity (hashing, verification, complexity defaults). No custom crypto.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,7 +89,7 @@ LoginAnonymously_LoggedIn_ReturnsBadRequest
 LoginAnonymously_FailedToCreateUser_ReturnsBadRequest
 ```
 
-Endpoints are tested by **calling the static handler directly** with mocked `UserManager` / `SignInManager` and a hand-built `ClaimsPrincipal` — no `WebApplicationFactory`, no test database. Assert on the typed result and verify the manager interactions:
+At this tier, endpoints are tested by **calling the static handler directly** with mocked `UserManager` / `SignInManager` and a hand-built `ClaimsPrincipal` — no `WebApplicationFactory`, no Postgres. That also means the whole request pipeline (routing, auth middleware, model binding, endpoint filters) is skipped here; anything that depends on it belongs in the integration tier below. Assert on the typed result and verify the manager interactions:
 
 ```csharp
 var result = await AuthEndpoints.LoginAnonymously(NotAuthenticatedPrincipal, userManager.Object, signInManager.Object);
@@ -98,8 +98,22 @@ Assert.IsType<Ok>(result.Result);
 userManager.Verify(m => m.CreateAsync(It.Is<AppUser>(p => p.IsAnonymous == true)));
 ```
 
-This is why handlers return `Results<...>` rather than `IResult` — keep new handlers testable the same way. Shared mock factories (`GetMockUserManager`, `GetMockSignInManager`) and principals live at the bottom of `AuthEndpointsTests.cs`.
+This is why handlers return `Results<...>` rather than `IResult` — keep new handlers testable the same way. Shared mock factories (`GetMockUserManager`, `GetMockSignInManager`) and principals live at the bottom of `AuthEndpointsTests.cs`. `GameEndpointsTests` follows the same shape but backs `ApplicationDbContext` with EF's InMemory provider (a fresh database per test) instead of mocking it directly, since the handler under test uses it for real reads/writes.
+
+### Integration tests
+
+`backend/integration-tests/Ahlcg.ApiService.IntegrationTests` exists because EF's InMemory provider does not enforce unique indexes, so it cannot prove the `POST /games` idempotency behaviour (same key + same user → one row; same key + different users → two rows). Everything InMemory *can't* cover goes here instead, driven over real HTTP against the real app and real Postgres — not by calling handlers with mocks.
+
+A collection fixture (`AppFixture`, shared across the test class via `[Collection]`/`ICollectionFixture`) starts the app once:
+
+- `DistributedApplicationTestingBuilder.CreateAsync<Projects.Ahlcg_AppHost>()`, with the `webfrontend`/`webfrontend-installer` resources (no Node in CI) and `pgadmin` (dev convenience only) removed from `builder.Resources` before building. `postgresdb`, `migrator`, and `apiservice` stay — running the real migrator is what proves the migration applies.
+- `app.StartAsync()`, then `app.ResourceNotifications.WaitForResourceHealthyAsync("apiservice")`.
+- Tests get a fresh `HttpClient` per call (`AppFixture.CreateClient()`) with its own `CookieContainer`, and a fresh `ApplicationDbContext` (`AppFixture.CreateDbContext()`) for direct-DB assertions (e.g. counting rows for an idempotency key).
+
+**Why HTTPS, not HTTP:** `ConfigureApplicationCookie` sets `SecurePolicy = Always`, and .NET's `CookieContainer` will not send a `Secure` cookie over plain `http://` (no localhost exception, unlike browsers). So the fixture talks to the `https` endpoint — which requires `AddProject<Ahlcg_ApiService>("apiservice", launchProfileName: "https")` in `AppHost.cs`, since the default `http` launch profile has no HTTPS endpoint at all. Certificate trust is handled by disabling validation on the test client (`ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator`) rather than trusting the dev cert, since CI never does the latter.
+
+Requires a container runtime — Docker or Podman both work, since Aspire drives whichever DCP finds (a real Postgres container is started for each test run). Runs via the same `dotnet test` as the unit tests; GitHub's `ubuntu-latest` runners provide Docker, so CI needs no extra setup, but this tier is slower than the InMemory-backed unit tests.
 
 ## What is not tested
 
-No integration tests, no end-to-end tests, no test database. Visual regression is covered by Chromatic over Storybook stories, not by specs.
+No end-to-end tests against the frontend. Visual regression is covered by Chromatic over Storybook stories, not by specs.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,13 +72,15 @@ ESLint runs `strictTypeChecked` on specs too, and `eslint-plugin-jasmine` is sti
 
 ## Backend
 
-xUnit + Moq, in `backend/unit-tests/Ahlcg.ApiService.Tests/`. Coverage via coverlet (`XPlat Code Coverage`), aggregated by `reportgenerator`.
+xUnit + Moq, in `backend/unit-tests/Ahlcg.ApiService.Tests/`. Coverage via `dotnet-coverage`, aggregated by `reportgenerator`.
+
+**Coverage must be collected with `dotnet-coverage`, not coverlet.** The integration tests drive the API in a process DCP spawns; coverlet (`--collect:"XPlat Code Coverage"`) only instruments the test host, so it scored `Ahlcg.ApiService` at ~1.65% and showed `Program.cs` and every `Map*` method as untested. `dotnet-coverage` instruments the whole process tree. Scope and two silent-failure traps are documented in `backend/coverage.runsettings`.
 
 ```bash
 cd backend
 dotnet test
 dotnet test --filter "FullyQualifiedName~AuthEndpointsTests"
-dotnet test --collect:"XPlat Code Coverage"
+dotnet-coverage collect --settings coverage.runsettings --output coverage.cobertura.xml --output-format cobertura -- dotnet test
 ```
 
 Test names follow `{Method}_{Scenario}_{Expected}`:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-.NET SDK 10.x, Node.js with npm, and Docker (Aspire starts Postgres in a container).
+.NET SDK 10.x, Node.js with npm, and a container runtime — Docker or Podman (Aspire starts Postgres in a container). The container runtime is needed for `dotnet test` too, not just for running the app: the backend integration tests start the real AppHost. See [testing.md](testing.md).
 
 ## Running
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -58,7 +58,7 @@ Scalar API explorer: `/scalar/v1`. OpenAPI: `/openapi/v1.json`.
 | Build | `dotnet build` |
 | Test | `dotnet test` |
 | Single test class | `dotnet test --filter "FullyQualifiedName~AuthEndpointsTests"` |
-| Coverage | `dotnet test --collect:"XPlat Code Coverage"` |
+| Coverage | `dotnet-coverage collect --settings coverage.runsettings --output coverage.cobertura.xml --output-format cobertura -- dotnet test` (needs `dotnet tool install -g dotnet-coverage`) |
 | Add migration (from `Ahlcg.ApiService`) | `dotnet ef migrations add {Name}` |
 
 `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` is set on every project — a warning fails the build.
@@ -92,7 +92,7 @@ Commit messages follow `area: what changed` (`ux: keyboard input manager`, `test
 
 It calls the reusable `backend.yml` / `frontend.yml`, then a `coveralls` job posts `parallel-finished` with `carryforward: frontend,backend`.
 
-**backend.yml** — .NET 10, installs `dotnet-reportgenerator-globaltool` and `dotnet-sonarscanner`, wraps restore/build/test in a Sonar session (`rombolshak_ahlcg_backend`), collects XPlat coverage, generates `coveragereport/` (HTML + Cobertura + SonarQube, excluding generated code and migrations), uploads `Cobertura.xml` to Coveralls.
+**backend.yml** — .NET 10, installs `dotnet-reportgenerator-globaltool`, `dotnet-coverage`, `dotnet-sonarscanner`, and the Aspire CLI (then `aspire certs trust`, so the integration tests can serve HTTPS), wraps restore/build/test in a Sonar session (`rombolshak_ahlcg_backend`), collects coverage across the whole process tree with `dotnet-coverage`, generates `coveragereport/` (HTML + Cobertura + SonarQube, excluding generated code and migrations), uploads `Cobertura.xml` to Coveralls.
 
 **frontend.yml** — Node latest with npm cache, `npm ci --force` (a workaround for Tailwind 4 resolution), `npm run ci:all`, Coveralls, then a SonarQube scan using `frontend/sonar-project.properties` (project key `rombolshak_ahlcg`).
 


### PR DESCRIPTION
Adds the `Game` entity, its migration, and `POST /games` — the first game-shaped thing this backend stores. The configuration payload is opaque per #198: stored in a `jsonb` column and handed back unchanged, never parsed or validated for its contents. Idempotency is enforced by a unique index on `(OwnerId, IdempotencyKey)` with an insert-then-recover handler, rather than a check-then-insert that would race.

## Acceptance criteria

- [x] A `Game` entity exists with owner, timestamps and an opaque configuration payload, and no property whose type or name encodes an Arkham concept
- [x] A migration adds the table; it is generated with `dotnet ef migrations add`, not hand-written, and the model snapshot is not hand-edited
- [x] `POST /games` requires authorization and returns `401` without a session cookie
- [x] A successful create returns the new game's id, and the game is associated with the calling user
- [x] Two creates with the same idempotency key from the same user produce one row, and both responses name the same game
- [x] Two creates with the same key from *different* users produce two games
- [x] The configuration payload comes back byte-identical to what was sent — **see deviation below**
- [x] The route appears in `/openapi/v1.json` with a description
- [x] Build passes with `TreatWarningsAsErrors`

## Deviations from the issue

Three, all agreed before implementation:

1. **Byte-identical relaxed to semantic identity.** The issue asks for both a `jsonb` column and a byte-identical round-trip. `jsonb` normalizes whitespace, reorders object keys and drops duplicates, so the two cannot both hold. `jsonb` was kept; the test asserts semantic JSON equality via `JsonElement.DeepEquals`.
2. **The idempotency key travels in an `Idempotency-Key` header**, not the request body, following the IETF draft convention.
3. **A new integration test project** — `backend/integration-tests/Ahlcg.ApiService.IntegrationTests`. EF's InMemory provider does not enforce unique indexes, so it cannot prove the two idempotency criteria at all. These tests drive the real API over real HTTP against the real Aspire-orchestrated Postgres.

Two changes outside the issue's file list follow from that third point:

- `AppHost.cs` runs `apiservice` on its `https` launch profile. The auth cookie is `Secure`, and .NET's `CookieContainer` will not send a `Secure` cookie over plain HTTP (no localhost exception, unlike browsers). The profile already declared both URLs; Aspire was just picking the first one.
- `Ahlcg.AppHost.csproj` bumps `Aspire.AppHost.Sdk` 13.2.2 → 13.4.6. Every other Aspire package was already on 13.4.6 from #478; only the SDK pin was left behind, and `Aspire.Hosting.Testing` refuses to run against the older one.

## Verification

```
cd backend
dotnet build   # Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test    # Ahlcg.ApiService.Tests             Passed  19/19
               # Ahlcg.ApiService.IntegrationTests  Passed   7/7
```

The integration tier requires a container runtime (Docker or Podman); it was verified locally under Podman. Every acceptance criterion above has an executable assertion behind it.

Worth noting for reviewers: the endpoint was briefly broken by a framework bug in the `AddValidation()` walker ([dotnet/aspnetcore#65424](https://github.com/dotnet/aspnetcore/issues/65424)) that 500'd on any DTO containing a `JsonElement`. All 19 unit tests passed against it, because handler-level tests bypass the request pipeline entirely. Only the HTTP-level tests caught it. The bug is fixed in current SDKs and no workaround remains in this branch.

## Docs

`docs/README.md` and `docs/architecture.md` both asserted that no game API exists; that status is now split so game *creation* reads as implemented while game *state* persistence remains absent. `api.md`, `backend.md`, `testing.md`, `security.md` and `workflow.md` updated alongside.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated game creation through `POST /games`.
  - Supports JSON configuration, ownership tracking, timestamps, and idempotency keys.
  - Repeated requests with the same key safely return the existing game.

- **Documentation**
  - Updated API, architecture, backend, security, testing, and workflow documentation.

- **Testing**
  - Added unit and end-to-end coverage for authentication, persistence, validation, ownership, configuration handling, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->