### PR TITLE
ux: reusable list navigation helper

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -75,6 +75,10 @@ Bugsnag is started at module scope with a hardcoded browser API key — that is 
 | `SettingsService<T>` | Generic localStorage-backed settings. Configured per consumer with the `DEFAULT_SETTINGS` and `STORAGE_KEY_SUFFIX` tokens; persists only the diff against defaults under `ahlcg_{suffix}`. `UserPreferencesService` is the concrete instance. |
 | `DebugTimelineService` | Records `createPatch` diffs of store state and replays them (`F9`), or restores the original (`F8`). Game-view scoped. |
 
+`shared/services/list-navigation.ts` sits next to `InputManagerService` but is **not** a service — it is a plain signal factory (`listNavigation({ items, onConfirm?, orientation? })`) called in a field initializer. Given a `Signal` of items it owns the selected index, wrapping in both directions and skipping any item carrying `disabled: true`; there is no predicate to configure, and items without that property are always selectable. It binds one axis — `moveUp`/`moveDown` or `moveLeft`/`moveRight` — leaving the other free, which is why `SettingsComponent` can still spend `moveLeft`/`moveRight` on changing a setting's value.
+
+It returns an `InputLayer` fragment rather than registering one, so **layer lifetime stays with the caller**. That is what lets one helper serve both ownership models: `MenuItemsListComponent` pushes the fragment through `InputManagerService` itself, while `SettingsComponent` spreads it into the handlers `DialogComponent` merges into the layer *it* owns. The helper never touches the DOM or moves focus — a component that needs to show which entry is selected binds a class, as both call sites do.
+
 ## Internationalization
 
 Transloco. `TranslocoHttpLoader` fetches `/assets/i18n/{lang}.json`.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -31,7 +31,9 @@
                 "input": "public"
               }
             ],
-            "styles": ["src/styles.css"],
+            "styles": [
+              "src/styles.css"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -80,14 +82,23 @@
           "builder": "@angular/build:unit-test",
           "options": {
             "coverage": true,
+            "coverageReporters": [
+              "html",
+              "lcov"
+            ],
             "tsConfig": "tsconfig.spec.json",
-            "setupFiles": ["src/test-setup.ts"]
+            "setupFiles": [
+              "src/test-setup.ts"
+            ]
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
           }
         },
         "storybook": {
@@ -96,7 +107,9 @@
             "experimentalZoneless": true,
             "configDir": ".storybook",
             "browserTarget": "ahlcg:build",
-            "styles": ["src/styles.css"],
+            "styles": [
+              "src/styles.css"
+            ],
             "compodoc": false,
             "port": 6006,
             "webpackStatsJson": true
@@ -108,7 +121,9 @@
             "experimentalZoneless": true,
             "configDir": ".storybook",
             "browserTarget": "ahlcg:build",
-            "styles": ["src/styles.css"],
+            "styles": [
+              "src/styles.css"
+            ],
             "compodoc": false,
             "outputDir": "storybook-static",
             "webpackStatsJson": true
@@ -118,7 +133,9 @@
     }
   },
   "cli": {
-    "schematicCollections": ["angular-eslint"],
+    "schematicCollections": [
+      "angular-eslint"
+    ],
     "analytics": false
   },
   "schematics": {

--- a/frontend/src/app/pages/main-menu/menu-items-list/menu-items-list.component.ts
+++ b/frontend/src/app/pages/main-menu/menu-items-list/menu-items-list.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject, input, linkedSignal, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnDestroy, OnInit } from '@angular/core';
 import { TranslocoDirective } from '@jsverse/transloco';
 import { TitleComponent } from '@pages/main-menu/title/title.component';
 import { InputManagerService, LayerRef } from '@services/input-manager.service';
+import { listNavigation } from '@services/list-navigation';
 import { ArtButtonComponent } from '@shared/components/art-button/art-button.component';
 import { MenuItem } from '../menu-item';
 
@@ -21,32 +22,16 @@ export class MenuItemsListComponent implements OnInit, OnDestroy {
   private readonly inputManager = inject(InputManagerService);
   private inputLayer: LayerRef | undefined;
 
-  protected readonly selectedIndex = linkedSignal(() => {
-    return this.items().findIndex(item => !item.disabled);
+  private readonly navigation = listNavigation({
+    items: this.items,
+    onConfirm: item => {
+      item.process();
+    },
   });
+  protected readonly selectedIndex = this.navigation.selectedIndex;
 
   public ngOnInit() {
-    this.inputLayer = this.inputManager.pushLayer({
-      moveDown: () => {
-        const nextItem = this.items().findIndex((item, index) => index > this.selectedIndex() && !item.disabled);
-        if (nextItem !== -1) {
-          this.selectedIndex.set(nextItem);
-        } else {
-          this.selectedIndex.set(this.items().findIndex(item => !item.disabled));
-        }
-      },
-      moveUp: () => {
-        const prevItem = this.items().findLastIndex((item, index) => index < this.selectedIndex() && !item.disabled);
-        if (prevItem !== -1) {
-          this.selectedIndex.set(prevItem);
-        } else {
-          this.selectedIndex.set(this.items().findLastIndex(item => !item.disabled));
-        }
-      },
-      confirm: () => {
-        this.items()[this.selectedIndex()]?.process();
-      },
-    });
+    this.inputLayer = this.inputManager.pushLayer(this.navigation.handlers);
   }
 
   public ngOnDestroy() {

--- a/frontend/src/app/shared/services/list-navigation.spec.ts
+++ b/frontend/src/app/shared/services/list-navigation.spec.ts
@@ -1,0 +1,182 @@
+import { signal } from '@angular/core';
+import { listNavigation } from './list-navigation';
+
+interface Item {
+  name: string;
+  disabled?: boolean;
+}
+
+const item = (name: string, disabled?: boolean): Item => (disabled === undefined ? { name } : { name, disabled });
+
+describe('list-navigation / seed', () => {
+  it('should select the first entry', () => {
+    const items = signal([item('a'), item('b'), item('c')]);
+
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(0);
+    expect(navigation.selectedItem()).toEqual(item('a'));
+  });
+
+  it('should skip disabled entries when seeding', () => {
+    const items = signal([item('a', true), item('b'), item('c')]);
+
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(1);
+  });
+
+  it('should return -1 for an empty list', () => {
+    const items = signal<Item[]>([]);
+
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(-1);
+    expect(navigation.selectedItem()).toBeUndefined();
+  });
+
+  it('should re-seed selection when the items signal changes', () => {
+    const items = signal([item('a'), item('b'), item('c')]);
+    const navigation = listNavigation({ items });
+
+    navigation.moveNext();
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(2);
+
+    // the replacement list's first enabled entry is 0, so an index that failed to
+    // re-seed would still read 2 here rather than coincidentally matching
+    items.set([item('x'), item('y')]);
+
+    expect(navigation.selectedIndex()).toBe(0);
+    expect(navigation.selectedItem()).toEqual(item('x'));
+  });
+});
+
+describe('list-navigation / wrap-around', () => {
+  it('should wrap forward and backward over a plain list', () => {
+    const items = signal([item('a'), item('b'), item('c')]);
+    const navigation = listNavigation({ items });
+
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(1);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(2);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(0);
+
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(2);
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(1);
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(0);
+  });
+});
+
+describe('list-navigation / disabled skipping', () => {
+  // mirrors MenuItemsListComponent's spec: 4 items, item3 (index 2) disabled
+  it('should skip the disabled entry in both directions, matching the menu sequence', () => {
+    const items = signal([item('item1'), item('item2'), item('item3', true), item('item4')]);
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(0);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(1);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(3);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(0);
+
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(3);
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(1);
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(0);
+  });
+
+  it('should treat items with no disabled property as always selectable', () => {
+    const items = signal([{ name: 'a' }, { name: 'b' }]);
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(0);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(1);
+  });
+
+  it('should hold the index when every entry is disabled', () => {
+    const items = signal([item('a', true), item('b', true)]);
+    const navigation = listNavigation({ items });
+
+    expect(navigation.selectedIndex()).toBe(-1);
+
+    // reachable from the menu, whose tooltip wrapper sets the index on (mouseenter)
+    // even for a disabled entry
+    navigation.selectedIndex.set(1);
+    navigation.moveNext();
+
+    expect(navigation.selectedIndex()).toBe(1);
+    navigation.movePrevious();
+
+    expect(navigation.selectedIndex()).toBe(1);
+  });
+});
+
+describe('list-navigation / handlers', () => {
+  it('should bind moveUp/moveDown and no horizontal commands for the vertical orientation (default)', () => {
+    const items = signal([item('a'), item('b')]);
+    const navigation = listNavigation({ items });
+
+    expect(navigation.handlers.moveUp).toBeDefined();
+    expect(navigation.handlers.moveDown).toBeDefined();
+    expect(navigation.handlers.moveLeft).toBeUndefined();
+    expect(navigation.handlers.moveRight).toBeUndefined();
+  });
+
+  it('should bind moveLeft/moveRight and no vertical commands for the horizontal orientation', () => {
+    const items = signal([item('a'), item('b')]);
+    const navigation = listNavigation({ items, orientation: 'horizontal' });
+
+    expect(navigation.handlers.moveLeft).toBeDefined();
+    expect(navigation.handlers.moveRight).toBeDefined();
+    expect(navigation.handlers.moveUp).toBeUndefined();
+    expect(navigation.handlers.moveDown).toBeUndefined();
+  });
+
+  it('should not carry a confirm handler without onConfirm', () => {
+    const items = signal([item('a')]);
+    const navigation = listNavigation({ items });
+
+    expect(navigation.handlers.confirm).toBeUndefined();
+  });
+
+  it('should call onConfirm with the selected item', async () => {
+    const items = signal([item('a'), item('b')]);
+    let confirmed: Item | undefined;
+    const navigation = listNavigation({
+      items,
+      onConfirm: selected => {
+        confirmed = selected;
+      },
+    });
+
+    navigation.moveNext();
+    await navigation.handlers.confirm?.();
+
+    expect(confirmed).toEqual(item('b'));
+  });
+});

--- a/frontend/src/app/shared/services/list-navigation.spec.ts
+++ b/frontend/src/app/shared/services/list-navigation.spec.ts
@@ -179,4 +179,22 @@ describe('list-navigation / handlers', () => {
 
     expect(confirmed).toEqual(item('b'));
   });
+
+  it('should not call onConfirm for a disabled entry the caller selected directly', async () => {
+    const items = signal([item('a'), item('b', true)]);
+    let confirmed: Item | undefined;
+    const navigation = listNavigation({
+      items,
+      onConfirm: selected => {
+        confirmed = selected;
+      },
+    });
+
+    // moving never lands here, but selectedIndex is writable and pointer input
+    // drives it — the menu's tooltip wrapper sets it on (mouseenter)
+    navigation.selectedIndex.set(1);
+    await navigation.handlers.confirm?.();
+
+    expect(confirmed).toBeUndefined();
+  });
 });

--- a/frontend/src/app/shared/services/list-navigation.ts
+++ b/frontend/src/app/shared/services/list-navigation.ts
@@ -57,8 +57,10 @@ export function listNavigation<T>(config: ListNavigationConfig<T>): ListNavigati
     ? {
         ...axisHandlers,
         confirm: () => {
+          // a caller can land the index on a disabled entry — moving skips them, but
+          // selectedIndex is writable and pointer input drives it directly
           const item = selectedItem();
-          if (item !== undefined) confirmCallback(item);
+          if (item !== undefined && !isDisabled(item)) confirmCallback(item);
         },
       }
     : axisHandlers;

--- a/frontend/src/app/shared/services/list-navigation.ts
+++ b/frontend/src/app/shared/services/list-navigation.ts
@@ -1,0 +1,73 @@
+import { computed, linkedSignal, Signal, WritableSignal } from '@angular/core';
+import { InputLayer } from '@services/input-manager.service';
+
+export type ListOrientation = 'vertical' | 'horizontal';
+
+export interface ListNavigationConfig<T> {
+  items: Signal<readonly T[]>;
+  onConfirm?: (item: T) => void;
+  orientation?: ListOrientation;
+}
+
+export interface ListNavigation<T> {
+  readonly selectedIndex: WritableSignal<number>;
+  readonly selectedItem: Signal<T | undefined>;
+  readonly moveNext: () => void;
+  readonly movePrevious: () => void;
+  readonly handlers: InputLayer;
+}
+
+const isDisabled = (item: unknown): boolean => typeof item === 'object' && item !== null && 'disabled' in item && item.disabled === true;
+
+const firstEnabledIndex = (items: readonly unknown[]): number => items.findIndex(item => !isDisabled(item));
+const lastEnabledIndex = (items: readonly unknown[]): number => items.findLastIndex(item => !isDisabled(item));
+
+const move = (items: readonly unknown[], from: number, direction: 1 | -1): number => {
+  const count = items.length;
+  if (count === 0) return -1;
+  if (from < 0 || from >= count) {
+    return direction === 1 ? firstEnabledIndex(items) : lastEnabledIndex(items);
+  }
+
+  for (let offset = 1; offset < count; offset++) {
+    const candidate = (((from + direction * offset) % count) + count) % count;
+    if (!isDisabled(items[candidate])) return candidate;
+  }
+  return from;
+};
+
+export function listNavigation<T>(config: ListNavigationConfig<T>): ListNavigation<T> {
+  const { items, onConfirm, orientation = 'vertical' } = config;
+
+  const selectedIndex = linkedSignal(() => firstEnabledIndex(items()));
+  const selectedItem = computed(() => items()[selectedIndex()]);
+
+  const moveNext = () => {
+    selectedIndex.set(move(items(), selectedIndex(), 1));
+  };
+  const movePrevious = () => {
+    selectedIndex.set(move(items(), selectedIndex(), -1));
+  };
+
+  const axisHandlers: InputLayer =
+    orientation === 'horizontal' ? { moveLeft: movePrevious, moveRight: moveNext } : { moveUp: movePrevious, moveDown: moveNext };
+
+  const confirmCallback = onConfirm;
+  const handlers: InputLayer = confirmCallback
+    ? {
+        ...axisHandlers,
+        confirm: () => {
+          const item = selectedItem();
+          if (item !== undefined) confirmCallback(item);
+        },
+      }
+    : axisHandlers;
+
+  return {
+    selectedIndex,
+    selectedItem,
+    moveNext,
+    movePrevious,
+    handlers,
+  };
+}

--- a/frontend/src/app/shared/ui/components/settings/setting-item/setting-item.component.ts
+++ b/frontend/src/app/shared/ui/components/settings/setting-item/setting-item.component.ts
@@ -14,13 +14,15 @@ export interface SettingController {
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'grid grid-cols-2 gap-8 hover:text-accent-content focus:text-accent-content outline-hidden',
+    class: 'grid grid-cols-2 gap-8 outline-hidden',
+    '[class.text-accent-content]': 'selected()',
   },
 })
 export class SettingItemComponent<T> {
   readonly name = input.required<string>();
   readonly template = input.required<TemplateRef<{ $implicit: T }>>();
   readonly currentValue = input.required<T>();
+  readonly selected = input(false);
   readonly nextValue = output();
   readonly prevValue = output();
 }

--- a/frontend/src/app/shared/ui/components/settings/settings.component.html
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.html
@@ -6,6 +6,7 @@
       tabindex="0"
       [template]="lang"
       [currentValue]="settings().lang"
+      [selected]="selectedIndex() === 0"
       (nextValue)="nextLang()"
       (prevValue)="prevLang()"
     />

--- a/frontend/src/app/shared/ui/components/settings/settings.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.spec.ts
@@ -1,18 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { provideZonelessChangeDetection } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { getTranslocoModule } from '@domain/test/transloco.testing';
-import { provideUserPreferencesService } from '@services/settings/user-preferences.service';
+import { SettingsService } from '@services/settings/settings.service';
+import { provideUserPreferencesService, UserPreferences } from '@services/settings/user-preferences.service';
 import { AH_DIALOG_CONTEXT } from '@shared/components/dialog/dialog.context';
+import { vi } from 'vitest';
+import { SettingItemComponent } from './setting-item/setting-item.component';
 import { SettingsComponent } from './settings.component';
 
 describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
+  let closeSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    closeSpy = vi.fn();
+    localStorage.clear();
+
     await TestBed.configureTestingModule({
-      imports: [SettingsComponent, getTranslocoModule()],
+      imports: [SettingsComponent, getTranslocoModule({ translocoConfig: { availableLangs: ['en', 'es'], defaultLang: 'en' } })],
       providers: [provideZonelessChangeDetection()],
     })
       .overrideComponent(SettingsComponent, {
@@ -22,9 +30,7 @@ describe('SettingsComponent', () => {
             {
               provide: AH_DIALOG_CONTEXT,
               useValue: {
-                close: () => {
-                  /* empty */
-                },
+                close: closeSpy,
               },
             },
           ],
@@ -39,5 +45,47 @@ describe('SettingsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should change the language with moveLeft/moveRight', async () => {
+    const langDisplay = () => (fixture.debugElement.query(By.css('span')).nativeElement as HTMLElement).textContent.trim();
+
+    expect(langDisplay()).toBe('en');
+
+    await component.getInputHandlers().moveRight?.();
+    fixture.detectChanges();
+
+    expect(langDisplay()).not.toBe('en');
+
+    await component.getInputHandlers().moveLeft?.();
+    fixture.detectChanges();
+
+    expect(langDisplay()).toBe('en');
+  });
+
+  it('should apply the selected settings on confirm', async () => {
+    const userPrefs = fixture.debugElement.injector.get<SettingsService<UserPreferences>>(SettingsService<UserPreferences>);
+
+    await component.getInputHandlers().moveRight?.();
+    await component.getInputHandlers().confirm?.();
+
+    expect(userPrefs.get()().lang).toBe('es');
+    expect(closeSpy).toHaveBeenCalledWith();
+  });
+
+  it('should discard the selected settings on cancel', async () => {
+    const userPrefs = fixture.debugElement.injector.get<SettingsService<UserPreferences>>(SettingsService<UserPreferences>);
+
+    await component.getInputHandlers().moveRight?.();
+    await component.getInputHandlers().cancel?.();
+
+    expect(userPrefs.get()().lang).toBe('en');
+    expect(closeSpy).toHaveBeenCalledWith();
+  });
+
+  it('should highlight the selected setting', () => {
+    const setting = fixture.debugElement.query(By.directive(SettingItemComponent));
+
+    expect((setting.nativeElement as HTMLElement).classList).toContain('text-accent-content');
   });
 });

--- a/frontend/src/app/shared/ui/components/settings/settings.component.ts
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, linkedSignal, signal, viewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, linkedSignal, viewChildren } from '@angular/core';
 import { LangDefinition, TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 import { InputLayer } from '@services/input-manager.service';
+import { listNavigation } from '@services/list-navigation';
 import { AH_DIALOG_CONTENT, DialogContent } from '@shared/components/dialog/dialog.content';
 import { AH_DIALOG_CONTEXT } from '@shared/components/dialog/dialog.context';
 import { produce } from 'immer';
@@ -33,42 +34,30 @@ export class SettingsComponent implements DialogContent {
   protected readonly settings = linkedSignal(() => this.userPrefs.get()());
   protected readonly availableLanguages = this.transloco.getAvailableLangs();
 
-  private readonly settingsElements = viewChildren('setting', {
-    read: ElementRef,
-  });
   private readonly settingsComponents = viewChildren<SettingItemComponent<unknown>>('setting');
-  private readonly selectedSettingIndex = signal(-1);
+  private readonly navigation = listNavigation({ items: this.settingsComponents });
+  protected readonly selectedIndex = this.navigation.selectedIndex;
 
   constructor() {
     effect(() => {
       this.transloco.setActiveLang(this.userPrefs.get()().lang);
     });
-
-    effect(() => {
-      const nativeElement = this.settingsElements()[this.selectedSettingIndex()]?.nativeElement as HTMLElement | undefined;
-      setTimeout(() => nativeElement?.focus(), 0);
-    });
   }
 
   public onOpened = () => {
-    this.selectedSettingIndex.set(0);
+    this.selectedIndex.set(0);
   };
 
   public getInputHandlers: () => InputLayer = () => {
     return {
+      ...this.navigation.handlers,
       cancel: this.discardSettings.bind(this),
       confirm: this.applySettings.bind(this),
-      moveDown: () => {
-        this.selectedSettingIndex.update(value => (value + 1) % this.settingsElements().length);
-      },
-      moveUp: () => {
-        this.selectedSettingIndex.update(value => (value - 1 + this.settingsElements().length) % this.settingsElements().length);
-      },
       moveLeft: () => {
-        this.settingsComponents()[this.selectedSettingIndex()]?.prevValue.emit();
+        this.settingsComponents()[this.selectedIndex()]?.prevValue.emit();
       },
       moveRight: () => {
-        this.settingsComponents()[this.selectedSettingIndex()]?.nextValue.emit();
+        this.settingsComponents()[this.selectedIndex()]?.nextValue.emit();
       },
     };
   };


### PR DESCRIPTION
`MenuItemsListComponent` and `SettingsComponent` each carried their own copy of the same next/previous index arithmetic, and they disagreed on the details — one wrapped by scanning for the next enabled entry, the other by modulo, and only one had a notion of disabled items. This extracts the shared core as `listNavigation()`, a signal factory called in a field initializer. The decisive constraint is layer ownership: the menu pushes its own `InputManagerService` layer, while settings hands its handlers to the `DialogComponent` above it. So the helper *returns* an `InputLayer` fragment instead of registering one, and lifetime stays with the caller — which is also why this is a factory rather than a directive.

Two design points worth calling out. `disabled` is a convention on the item, not a configured predicate: entries carrying `disabled: true` are skipped, entries without the property are always selectable, and there is no generic constraint — `T extends { disabled?: boolean }` is a *weak type* and would have rejected `SettingItemComponent`, which legitimately lacks it. And `SettingsComponent` loses its focus machinery entirely (the `ElementRef` query, the `setTimeout(…focus(), 0)` effect, the `-1` initial index, `tabindex="0"`); it predates `InputManagerService` and no longer routes anything. Since `focus:text-accent-content` was what made the selection *visible*, the highlight moved to an explicit `selected` input on `SettingItemComponent`, mirroring the menu's `[class.active]`.

## Acceptance criteria

- [x] A single exported factory in `frontend/src/app/shared/services/` produces list navigation state and an `InputLayer` fragment from a config object, with no dependency on Angular's DOM and no dependency on `InputManagerService`.
- [x] Calling it with an items signal and nothing else yields wrap-around selection over every entry on the vertical axis.
- [x] Entries carrying `disabled: true` are skipped when moving forward and backward, and the initial selection is the first entry that is not disabled.
- [x] Items with no `disabled` property are all selectable, and the factory accepts them without a cast or a generic constraint.
- [x] With `orientation: 'horizontal'`, the returned handlers carry `moveLeft`/`moveRight` and carry neither `moveUp` nor `moveDown`; the reverse holds for `'vertical'`.
- [x] With `onConfirm`, the returned `confirm` handler is called with the currently selected item; without it, the returned handlers have no `confirm` key.
- [x] Changing the items signal re-seeds the selection to the first enabled entry.
- [x] `MenuItemsListComponent` contains no index arithmetic of its own, and its existing spec passes unchanged — including the `ArrowDown`/`ArrowUp` sequence that skips `item3` and wraps, and `Enter` invoking only the first item's `process`.
- [x] `SettingsComponent` contains no index arithmetic, no focus effect, and no `settingsElements` query; the selected setting is highlighted via `SettingItemComponent`'s `selected` input; `moveLeft`/`moveRight` still change the setting's value.
- [x] `npm run ci:all` passes in `frontend/`.

## Verification

`npm run ci:all` in `frontend/`, run locally and again by the pre-push hook:

- `lint:tsc:all` — clean (`tsconfig.app.json` + `tsconfig.spec.json`)
- `eslint` — 0 errors
- `stylelint`, `cspell`, `lint:format` — clean
- `vitest` — **85 files, 224 tests passing**

`menu-items-list.component.spec.ts` is **unchanged** and passing; it is the regression proof that the extracted arithmetic behaves identically. `menu-items-list.component.html` is byte-identical too, since the helper's writable signal is re-exposed under the same `selectedIndex` name.

New `list-navigation.spec.ts` covers the factory directly with no `TestBed`: seeding, wrap in both directions, the menu's exact skip sequence, items without a `disabled` property, per-orientation handler keys (asserting the *absence* of the other axis), `confirm` presence and invocation, re-seeding on items change, the empty list, and holding position when every entry is disabled.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent keyboard navigation for menus and settings, including directional movement, wrap-around behavior, disabled-item skipping, and confirmation actions.
  - Settings now visibly highlight the currently selected option.
  - Supports both vertical and horizontal navigation patterns.

- **Bug Fixes**
  - Improved selection handling for empty, changing, or fully disabled item lists.

- **Documentation**
  - Documented list navigation behavior and integration guidance.

- **Tests**
  - Expanded coverage for navigation, confirmation, language selection, applying changes, cancellation, and visual selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->