### PR TITLE
deps: pin angular-eslint to the 21 line, install with npm ci

### DIFF
--- a/backend/Ahlcg.AppHost/AppHost.cs
+++ b/backend/Ahlcg.AppHost/AppHost.cs
@@ -21,6 +21,7 @@ var apiService =
 
 builder
     .AddViteApp("webfrontend", "../../frontend", "start")
+    .WithNpm(true, "ci")
     .WithExternalHttpEndpoints()
     .WithReference(apiService)
     .WaitFor(apiService);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@types/jasmine": "~6.0.0",
         "@typescript-eslint/parser": "^8.60.1",
         "@vitest/coverage-v8": "^4.1.10",
-        "angular-eslint": "22.0.0",
+        "angular-eslint": "21.4.0",
         "chromatic": "^16.0.0",
         "cspell": "^10.0.0",
         "daisyui": "^5.5.19",
@@ -329,7 +329,6 @@
       "integrity": "sha512-9xE7G177R9G9Kte+4AtbEMlEeZUupnvdBUMVBlZRa/n4UDUyAkB/vj58KrzRCCIVQ/ypHVMwUilaDTO484dd+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.5",
         "rxjs": "7.8.2"
@@ -1146,7 +1145,6 @@
       "integrity": "sha512-9z9w7UxKKVmib5QHFZTOfJpAiSudqQwwEZFpQy31yaXR3tJw85xO5owi+66sgTpEvNh9Ix2THhcUq//ToP/0VA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -1216,77 +1214,112 @@
         }
       }
     },
+    "node_modules/@angular-eslint/builder": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-21.4.0.tgz",
+      "integrity": "sha512-3kgGmrVaCYbLtDjC8g4BmMBbdz4thsOB8/NYly8JtXM8EuDZEk5Pz6VTRpJR02ARprwayraTTmhyvq6OGBlQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
+        "@angular-devkit/core": ">= 21.0.0 < 22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cli": ">= 21.0.0 < 22.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-22.0.0.tgz",
-      "integrity": "sha512-rv15vGDpGW8zZFaLdhQ+iIO1f0bZds/xvuxoX277hFisXp5Kt6FumJNNIb4g/qxq3xsY46a7fD6R7KvGY3smHg==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-21.4.0.tgz",
+      "integrity": "sha512-/3H4BPbQ1BHJkkrUsfusZtmHc+qiFWBBZ9UDPWah4xZMjflexOK9U4GYeH7nMjcuyqFnIlMMeJJNwNLGt/hmdg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-22.0.0.tgz",
-      "integrity": "sha512-mKLScPZhqG64ic0KIQoxqSqCdkPwtEZuTOuunvc9lYTw05MJSHRUM2yVFODlCGq97c6BN1F6KBk2I+a+KFnr1g==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-21.4.0.tgz",
+      "integrity": "sha512-mow2DMj+xBvGl5t7jzC34R8YfbHbaGNyCNFzpovtl9qc0JbuqLyg6htmt8xb05f8ZjATOr4nz0ESt6HV4c51hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "22.0.0",
-        "@angular-eslint/utils": "22.0.0",
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/utils": "21.4.0",
         "ts-api-utils": "^2.1.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^8.0.0",
-        "eslint": "^9.0.0 || ^10.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-22.0.0.tgz",
-      "integrity": "sha512-y6XL5HJ8C31NpBvkVHpU3bWc+Rk9g1zRtHrs39omhuT29eEUcS3zu47HMFV6tf8rHOI97B2Mstg6qYS5XL9ATg==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-21.4.0.tgz",
+      "integrity": "sha512-sJEHx2WYnvOgPpzP1eHnUdRS06zgKmRxbiIR0JiCcaSen5iv1HlsMieXy//FS9TtNW+abHOy4UtDuGuSPflPFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "22.0.0",
-        "@angular-eslint/utils": "22.0.0",
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/utils": "21.4.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
       "peerDependencies": {
-        "@angular-eslint/template-parser": "22.0.0",
-        "@typescript-eslint/types": "^8.0.0",
-        "@typescript-eslint/utils": "^8.0.0",
-        "eslint": "^9.0.0 || ^10.0.0",
+        "@angular-eslint/template-parser": "21.4.0",
+        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
-    "node_modules/@angular-eslint/template-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-22.0.0.tgz",
-      "integrity": "sha512-jU5MKQ24bBB4J99gSSexmUrLm2LvTJZCuCHhNTQ1LavWX4e1lrIxhm+6pJILOm6Cixf8jyNXnHMty6nljX8J+Q==",
+    "node_modules/@angular-eslint/schematics": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-21.4.0.tgz",
+      "integrity": "sha512-crD6Hfxs7x5bN9FCqTZI7uVSiGvprfCS3MCPOpyIQl87bRr/9aNhnicJ3ROUHv+2A713BgPHIgiCII/bxzrfPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "22.0.0",
+        "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
+        "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
+        "@angular-eslint/eslint-plugin": "21.4.0",
+        "@angular-eslint/eslint-plugin-template": "21.4.0",
+        "ignore": "7.0.5",
+        "semver": "7.7.4",
+        "strip-json-comments": "3.1.1"
+      },
+      "peerDependencies": {
+        "@angular/cli": ">= 21.0.0 < 22.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/template-parser": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-21.4.0.tgz",
+      "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
         "eslint-scope": "9.1.2"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0 || ^10.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-22.0.0.tgz",
-      "integrity": "sha512-VFodMojghnPYm+B3U+HRYrqebPMj8NyobNjVzDdY8V5XIBW+4ivOSEINIz81G48rmm/NZKwj56+bJ88bVX4KIw==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-21.4.0.tgz",
+      "integrity": "sha512-7pi+Ga7QmdH5Ig/diau6fR5L4yubgKr9TOjdCg7OeuE/zo0O3osTCNT6JOodzS/iQM1kSCJFDoIBKFeUOttiNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "22.0.0"
+        "@angular-eslint/bundled-angular-compiler": "21.4.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^8.0.0",
-        "eslint": "^9.0.0 || ^10.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
@@ -12275,221 +12308,27 @@
       }
     },
     "node_modules/angular-eslint": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-22.0.0.tgz",
-      "integrity": "sha512-6tHLndzM6rU+2iuICakJS/hD1scK5sWLkcD7828zStT1ViA9zX8z9g/V1IlBiKEdZeMsl+m7K2DlNc34AkYyoQ==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-21.4.0.tgz",
+      "integrity": "sha512-LH7bWmtJvsubzwPoztnl1pWgI5X0VrfGTUITGSYcwn2J+SXuN/avzrKrxJmhUiIrNvLtfV+18GG6xZS1IGZdKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": ">= 22.0.0 < 23.0.0",
-        "@angular-devkit/schematics": ">= 22.0.0 < 23.0.0",
-        "@angular-eslint/builder": "22.0.0",
-        "@angular-eslint/eslint-plugin": "22.0.0",
-        "@angular-eslint/eslint-plugin-template": "22.0.0",
-        "@angular-eslint/schematics": "22.0.0",
-        "@angular-eslint/template-parser": "22.0.0",
+        "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
+        "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
+        "@angular-eslint/builder": "21.4.0",
+        "@angular-eslint/eslint-plugin": "21.4.0",
+        "@angular-eslint/eslint-plugin-template": "21.4.0",
+        "@angular-eslint/schematics": "21.4.0",
+        "@angular-eslint/template-parser": "21.4.0",
         "@typescript-eslint/types": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
       "peerDependencies": {
-        "@angular/cli": ">= 22.0.0 < 23.0.0",
-        "eslint": "^9.0.0 || ^10.0.0",
+        "@angular/cli": ">= 21.0.0 < 22.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": "*",
         "typescript-eslint": "^8.0.0"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/@angular-devkit/architect": {
-      "version": "0.2201.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.3.tgz",
-      "integrity": "sha512-5WX6rooTQZCh+yE9k3O5hc7nnQtzy1nw6fQpaTuCzIgPG8teQuVtdxegBsM3OcjJac1r+qJLo+KmTRfnqcfsyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "22.1.3",
-        "rxjs": "7.8.2"
-      },
-      "bin": {
-        "architect": "bin/cli.js"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/@angular-devkit/core": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.3.tgz",
-      "integrity": "sha512-ASK8oZVElt/Zpz5FrzJjLnnUbzp/fW57eFFSRgpA+n9KRnuFi6YvNdSS3HkG5049Jcukce+PiMBdfzw/jBVkEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.20.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.5",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/angular-eslint/node_modules/@angular-devkit/schematics": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.3.tgz",
-      "integrity": "sha512-ebY5bwZVB0onxxyTbJch//VidVVV8jo/F13n+TV5s/3ZywsC3/XZsfMHaxlFmpvP/G17+/C9JVoEXT+uwjT+/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "22.1.3",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "1.0.0",
-        "ora": "9.4.1",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/@angular-eslint/builder": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-22.0.0.tgz",
-      "integrity": "sha512-T2vWQYUhJs6iUlgocHV12OgoxbmN63f17a+tgW+3sYrKN0KAB3xuHsPOoYpRYoWqkVVC44HD441Ju4IDvo8vKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
-        "@angular-devkit/core": ">= 22.0.0 < 23.0.0"
-      },
-      "peerDependencies": {
-        "@angular/cli": ">= 22.0.0 < 23.0.0",
-        "eslint": "^9.0.0 || ^10.0.0",
-        "typescript": "*"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/@angular-eslint/schematics": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-22.0.0.tgz",
-      "integrity": "sha512-gsJQx6c+WIWC5d+NAqn4rRdUzwhinUCTNmCM9x4wygV9DrbAfVG+6OFPEbaDMryNvf0HYDcnGclbIbXjukGCaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": ">= 22.0.0 < 23.0.0",
-        "@angular-devkit/schematics": ">= 22.0.0 < 23.0.0",
-        "@angular-eslint/eslint-plugin": "22.0.0",
-        "@angular-eslint/eslint-plugin-template": "22.0.0",
-        "ignore": "7.0.5",
-        "semver": "7.8.0",
-        "strip-json-comments": "3.1.1"
-      },
-      "peerDependencies": {
-        "@angular/cli": ">= 22.0.0 < 23.0.0"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/magic-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
-      "integrity": "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/ora": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
-      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.2",
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/string-width": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-colors": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,7 @@
     "@types/jasmine": "~6.0.0",
     "@typescript-eslint/parser": "^8.60.1",
     "@vitest/coverage-v8": "^4.1.10",
-    "angular-eslint": "22.0.0",
+    "angular-eslint": "21.4.0",
     "chromatic": "^16.0.0",
     "cspell": "^10.0.0",
     "daisyui": "^5.5.19",


### PR DESCRIPTION
`npm ci` fails on `main`. `angular-eslint` was bumped to `22.0.0` in #513 while Angular itself stayed on 21, and `angular-eslint@22` peers on `@angular/cli >= 22.0.0 < 23.0.0` against this project's `@angular/cli@^21.2.15`:

```
npm error ERESOLVE could not resolve
npm error While resolving: angular-eslint@22.0.0
npm error Found: @angular/cli@21.2.20
npm error Could not resolve dependency:
npm error peer @angular/cli@">= 22.0.0 < 23.0.0" from angular-eslint@22.0.0
```

It went unnoticed because `npm install` falls back to a best-effort tree rather than failing, and `frontend.yml` runs `npm ci --force`. `chromatic.yml` runs plain `npm ci`, so that job has been broken, as is any fresh clone. The half-resolved tree is also why `@angular-eslint/builder:lint` went missing and `ng lint` stopped working locally.

## The fix

`angular-eslint` 22.0.0 → **21.4.0**, the newest release on the 21 line — still ahead of the 21.3.1 the bump started from, not a rollback. Every peer is satisfied against what is installed:

```
@angular/cli      >= 21.0.0 < 22.0.0     (have ^21.2.15)
eslint            ^8.57 || ^9 || ^10     (have ^10.4.1)
typescript-eslint ^8.0.0                 (have ^8.60.1)
```

Moving the whole Angular toolchain to 22 instead would be a framework upgrade, not a lint bump.

The lockfile shrinks by ~160 net lines as the duplicated Angular-22 branch of the tree drops out.

## AppHost now installs with `npm ci`

`AddViteApp(...).WithNpm(true, "ci")` — the lockfile is honoured on every AppHost start. This is what makes the pin load-bearing: a peer conflict now fails startup loudly instead of being silently resolved into a tree nobody else can reproduce. Worth knowing it is a louder failure mode than before — a bad Dependabot bump will break local startup rather than degrade quietly, which is precisely how this one hid.

## Verification

```
npm ci --dry-run       resolves cleanly — no ERESOLVE
npm run lint:all       0 errors, 38 warnings (unchanged baseline)
npx ng lint            works again — the builder resolves
npm test               254 tests / 88 files passed
npx ng build           succeeds
dotnet build           0 warnings (TreatWarningsAsErrors is on)
```

A full `npm ci` could not be completed locally: it deletes `node_modules` before installing and hit an `EPERM` on a locked native binary (`lightningcss.win32-x64-msvc.node`) held by a running build process. That is a Windows file-lock issue on one machine, not a repo problem — `--dry-run` completes the resolution step that was actually failing, and Linux CI will do the real thing.

## Note for a follow-up

`frontend.yml` line 30 carries `npm ci --force # tailwind 4 fails to resolve in angular-builder 19.1`. The repo is on Angular 21, so that comment is about a builder three majors old. The `--force` is what let this breakage reach `main` unnoticed. Worth checking whether it is still needed once this lands — not touched here to keep the fix reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved frontend setup reliability by ensuring clean, reproducible package installation during development.
  * Updated the Angular linting tool version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->