### PR TITLE
settings: account management

### DIFF
--- a/backend/Ahlcg.ApiService/AuthEndpoints.cs
+++ b/backend/Ahlcg.ApiService/AuthEndpoints.cs
@@ -20,7 +20,7 @@ public static class AuthEndpoints
         [Required] string Password);
 
     [PublicAPI]
-    public record UserDto(string? Email, bool IsAnonymous);
+    public record UserDto(string? Email, string? UserName, bool IsAnonymous);
     
     public static RouteGroupBuilder MapAuthEndpoints(this RouteGroupBuilder group)
     {
@@ -130,7 +130,7 @@ public static class AuthEndpoints
     {
         var user = await userManager.GetUserAsync(principal);
         return user is not null
-            ? TypedResults.Ok(new UserDto(user.Email, user.IsAnonymous))
+            ? TypedResults.Ok(new UserDto(user.Email, user.UserName, user.IsAnonymous))
             : TypedResults.Unauthorized();
     }
 

--- a/backend/unit-tests/Ahlcg.ApiService.Tests/AuthEndpointsTests.cs
+++ b/backend/unit-tests/Ahlcg.ApiService.Tests/AuthEndpointsTests.cs
@@ -336,7 +336,24 @@ public class AuthEndpointsTests
             userManager.Object);
 
         Assert.IsType<Ok<AuthEndpoints.UserDto>>(result.Result);
-        Assert.True(((Ok<AuthEndpoints.UserDto>)result.Result).Value?.IsAnonymous);
+        var user = ((Ok<AuthEndpoints.UserDto>)result.Result).Value;
+        Assert.True(user?.IsAnonymous);
+        Assert.False(string.IsNullOrEmpty(user?.UserName));
+    }
+
+    [Fact]
+    public async Task GetCurrentUser_LoggedInAsPermanent_ReturnsEmailAndUserName()
+    {
+        var userManager = GetMockUserManager();
+
+        var result = await AuthEndpoints.GetCurrentUser(
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, PermanentUser)])),
+            userManager.Object);
+
+        Assert.IsType<Ok<AuthEndpoints.UserDto>>(result.Result);
+        var user = ((Ok<AuthEndpoints.UserDto>)result.Result).Value;
+        Assert.Equal("test@test.com", user?.Email);
+        Assert.Equal("test user", user?.UserName);
     }
 
     [Fact]

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,7 +50,7 @@ Only the unknown-email-while-anonymous branch above preserves everything, by upg
 
 Returns the current session. Requires authorization.
 
-- `200 OK` → `{ "email": string | null, "isAnonymous": boolean }` (`UserDto`). `email` is `null` for anonymous accounts. There is no `id` or `userName` in the response.
+- `200 OK` → `{ "email": string | null, "userName": string | null, "isAnonymous": boolean }` (`UserDto`). `email` is `null` for anonymous accounts; `userName` is set for every account, and is a raw GUID for anonymous ones. There is no `id` in the response.
 - `401 Unauthorized` — no valid cookie.
 
 `AuthService` on the frontend treats `401` as "logged out", not as an error.

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -87,7 +87,6 @@
     "sign_in": {
       "title": "Confront the Mythos",
       "message": "Before the first draw, choose your anchor. Prefer a lightweight charm for quick entry. You can always bind a heavier pact later.",
-      "later_hint": "You can sign the register later, from Settings.",
       "anonymous": {
         "title": "The Lucky Talisman",
         "lead": "Perfect for trying new decks or solo runs.",
@@ -102,18 +101,59 @@
         "credentials": "Full account registration",
         "device": "Access from any device",
         "name": "Your own name online",
-        "duration": "Data is stored for at least 1 year",
-        "legend": "Your particulars",
-        "email": "Email",
-        "username": "Name",
-        "password": "Password",
-        "submit": "Bind account",
-        "back": "Go back"
-      },
+        "duration": "Data is stored for at least 1 year"
+      }
+    },
+    "credentials_form": {
+      "title": "The Binding Rite",
+      "legend": "Your particulars",
+      "email": "Email",
+      "username": "Name",
+      "password": "Password",
+      "submit": "Bind account",
+      "back": "Go back",
+      "cancel": "Not now",
       "errors": {
         "wrong_password": "The sigil is incorrect. The Tome rejects your touch. Forgot your binding?",
         "generic": "The archives are silent. An eldritch interference blocks our reach. Try again later."
       }
     }
+  },
+  "settings": {
+    "language": "Language",
+    "account": {
+      "row": "Account",
+      "title": "Your Account",
+      "back": "Back",
+      "anonymous": {
+        "name_label": "Alias",
+        "state": "A wandering spirit, unbound.",
+        "detail": "This account lives on this device alone. Signing out deletes it beyond recall, along with everything it carries.",
+        "upgrade": "Bind account",
+        "sign_out": "Sign out"
+      },
+      "permanent": {
+        "name_label": "Name",
+        "email_label": "Email",
+        "state": "A pact sealed and lasting.",
+        "detail": "Reachable from any device, however far the investigation strays.",
+        "sign_out": "Sign out"
+      },
+      "signed_out": {
+        "state": "No pact is sealed.",
+        "detail": "Sign in to resume an investigation already begun.",
+        "sign_in": "Sign in"
+      },
+      "sign_out_warning": {
+        "title": "The Pact Unravels",
+        "message": "This account exists only here, only now. Signing out deletes it beyond recall, along with everything it carries.",
+        "confirm": "Delete and sign out",
+        "cancel": "Stay bound"
+      }
+    }
+  },
+  "confirm_dialog": {
+    "confirm": "Confirm",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/app/pages/main-menu/main-menu.component.spec.ts
+++ b/frontend/src/app/pages/main-menu/main-menu.component.spec.ts
@@ -66,7 +66,7 @@ describe('MainMenuComponent', () => {
   });
 
   it('should display continue button if authenticated', () => {
-    mockAuthService._user.next({ isAnonymous: true, email: null });
+    mockAuthService._user.next({ isAnonymous: true, email: null, userName: 'anon-guid' });
     TestBed.tick();
 
     expect(fixture.debugElement.query(By.css('[data-testId=continue]'))).toBeTruthy();

--- a/frontend/src/app/shared/services/auth.interceptor.spec.ts
+++ b/frontend/src/app/shared/services/auth.interceptor.spec.ts
@@ -46,7 +46,7 @@ describe('authInterceptor', () => {
 
     expect(open).toHaveBeenCalledWith(SignInComponent, SIGN_IN_DIALOG_OPTIONS);
 
-    dialogResult$.next({ isAnonymous: true, email: null });
+    dialogResult$.next({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
     httpMock.expectOne('/api/games').flush({ id: '1' });
 
@@ -110,7 +110,7 @@ describe('authInterceptor', () => {
     });
 
     httpMock.expectOne('/api/games').flush(null, { status: 401, statusText: 'Unauthorized' });
-    dialogResult$.next({ isAnonymous: true, email: null });
+    dialogResult$.next({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
     httpMock.expectOne('/api/games').flush(null, { status: 401, statusText: 'Unauthorized' });
 

--- a/frontend/src/app/shared/services/auth.service.spec.ts
+++ b/frontend/src/app/shared/services/auth.service.spec.ts
@@ -24,9 +24,9 @@ describe('AuthService', () => {
   });
 
   it('should load user model', () => {
-    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null, userName: 'anon-guid' });
     service.currentUser.subscribe(data => {
-      expect(data).toEqual({ isAnonymous: true, email: null } satisfies User);
+      expect(data).toEqual({ isAnonymous: true, email: null, userName: 'anon-guid' } satisfies User);
     });
   });
 
@@ -47,11 +47,11 @@ describe('AuthService', () => {
     });
 
     http.expectOne('/api/auth/loginAnonymously').flush(null);
-    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
-    expect(result).toEqual({ isAnonymous: true, email: null } satisfies User);
+    expect(result).toEqual({ isAnonymous: true, email: null, userName: 'anon-guid' } satisfies User);
     service.currentUser.subscribe(data => {
-      expect(data).toEqual({ isAnonymous: true, email: null } satisfies User);
+      expect(data).toEqual({ isAnonymous: true, email: null, userName: 'anon-guid' } satisfies User);
     });
   });
 
@@ -68,13 +68,13 @@ describe('AuthService', () => {
 
     expect(req.request.body).toEqual(credentials);
     req.flush(null);
-    http.expectOne('/api/auth/info').flush({ isAnonymous: false, email: 'a@example.com' });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: false, email: 'a@example.com', userName: 'a' });
 
-    expect(result).toEqual({ isAnonymous: false, email: 'a@example.com' } satisfies User);
+    expect(result).toEqual({ isAnonymous: false, email: 'a@example.com', userName: 'a' } satisfies User);
   });
 
   it('should use signIn to upgrade an anonymous session, leaving currentUser permanent', () => {
-    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
     const credentials: Credentials = { email: 'a@example.com', username: 'a', password: 'P@ssw0rd' };
     let result: User | undefined;
@@ -83,13 +83,13 @@ describe('AuthService', () => {
     });
 
     http.expectOne('/api/auth/signIn').flush(null);
-    http.expectOne('/api/auth/info').flush({ isAnonymous: false, email: 'a@example.com' });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: false, email: 'a@example.com', userName: 'a' });
 
-    expect(result).toEqual({ isAnonymous: false, email: 'a@example.com' } satisfies User);
+    expect(result).toEqual({ isAnonymous: false, email: 'a@example.com', userName: 'a' } satisfies User);
   });
 
   it('should POST to logout, refresh currentUser, and leave currentUser undefined after the following 401', () => {
-    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null });
+    http.expectOne('/api/auth/info').flush({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
     let emitted = false;
     service.logout().subscribe(value => {

--- a/frontend/src/app/shared/services/auth.service.ts
+++ b/frontend/src/app/shared/services/auth.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, catchError, map, Observable, of, switchMap, tap } from
 
 export interface User {
   email: string | null;
+  userName: string | null;
   isAnonymous: boolean;
 }
 

--- a/frontend/src/app/shared/services/confirm-dialog.service.spec.ts
+++ b/frontend/src/app/shared/services/confirm-dialog.service.spec.ts
@@ -1,0 +1,63 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { getTranslocoModule } from '@domain/test/transloco.testing';
+import { ConfirmDialogService } from './confirm-dialog.service';
+
+describe('ConfirmDialogService', () => {
+  let service: ConfirmDialogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [getTranslocoModule()],
+      providers: [provideZonelessChangeDetection()],
+    });
+    service = TestBed.inject(ConfirmDialogService);
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('dialog').forEach(dialog => {
+      dialog.remove();
+    });
+  });
+
+  it('should resolve true when confirmed', () => {
+    let result: boolean | undefined;
+    service.confirm({ titleKey: 'settings.account.sign_out_warning.title', messageKey: 'settings.account.sign_out_warning.message' }).subscribe(value => {
+      result = value;
+    });
+    TestBed.tick();
+
+    document.querySelector<HTMLElement>('[data-testId=confirm]')?.click();
+    TestBed.tick();
+
+    expect(result).toBe(true);
+  });
+
+  it('should resolve false when cancelled', () => {
+    let result: boolean | undefined;
+    service.confirm({ titleKey: 'settings.account.sign_out_warning.title', messageKey: 'settings.account.sign_out_warning.message' }).subscribe(value => {
+      result = value;
+    });
+    TestBed.tick();
+
+    document.querySelector<HTMLElement>('[data-testId=cancel]')?.click();
+    TestBed.tick();
+
+    expect(result).toBe(false);
+  });
+
+  // The one behaviour that makes `confirm()` safe to pipe into an action without hanging: a
+  // dialog closed by any other route — not just its own Cancel button — still answers.
+  it('should resolve false when the dialog is dismissed without a decision', () => {
+    let result: boolean | undefined;
+    service.confirm({ titleKey: 'settings.account.sign_out_warning.title', messageKey: 'settings.account.sign_out_warning.message' }).subscribe(value => {
+      result = value;
+    });
+    TestBed.tick();
+
+    document.querySelector('dialog')?.dispatchEvent(new Event('close'));
+    TestBed.tick();
+
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/app/shared/services/confirm-dialog.service.ts
+++ b/frontend/src/app/shared/services/confirm-dialog.service.ts
@@ -1,0 +1,43 @@
+import { Binding, inject, inputBinding, Service } from '@angular/core';
+import { ConfirmAppearance, ConfirmButtonKey, ConfirmDialogComponent } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { defaultIfEmpty, Observable } from 'rxjs';
+import { DialogService } from './dialog.service';
+
+export interface ConfirmOptions {
+  readonly titleKey: string;
+  readonly messageKey: string;
+  readonly confirmKey?: string;
+  readonly cancelKey?: string;
+  readonly appearance?: ConfirmAppearance;
+  /** Which button opens selected. Defaults to confirm; a destructive prompt should ask for cancel. */
+  readonly defaultButton?: ConfirmButtonKey;
+}
+
+/**
+ * The public API for a confirm/cancel prompt — `ConfirmDialogComponent` is an implementation
+ * detail opened through here, not instantiated directly. `confirm()` always yields a decision:
+ * a dialog dismissed some other way still resolves `false`, so a caller piping into an action
+ * never hangs.
+ */
+@Service()
+export class ConfirmDialogService {
+  private readonly dialog = inject(DialogService);
+
+  public confirm(options: ConfirmOptions): Observable<boolean> {
+    const bindings: Binding[] = [inputBinding('messageKey', () => options.messageKey), inputBinding('appearance', () => options.appearance ?? 'primary')];
+
+    // Omitted rather than defaulted here: `ConfirmDialogComponent`'s own `input()` default is the
+    // one place that fallback lives. A binding for an `undefined` key would override it with
+    // "undefined" rendered as a string, not fall through to the component's default.
+    const confirmKey = options.confirmKey;
+    if (confirmKey !== undefined) bindings.push(inputBinding('confirmKey', () => confirmKey));
+
+    const cancelKey = options.cancelKey;
+    if (cancelKey !== undefined) bindings.push(inputBinding('cancelKey', () => cancelKey));
+
+    const defaultButton = options.defaultButton;
+    if (defaultButton !== undefined) bindings.push(inputBinding('defaultButton', () => defaultButton));
+
+    return this.dialog.open(ConfirmDialogComponent, { titleKey: options.titleKey, bindings }).pipe(defaultIfEmpty(false));
+  }
+}

--- a/frontend/src/app/shared/services/dialog.service.ts
+++ b/frontend/src/app/shared/services/dialog.service.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ApplicationRef, createComponent, EnvironmentInjector, inject, OutputRef, Service, Type } from '@angular/core';
+import { ApplicationRef, Binding, createComponent, EnvironmentInjector, inject, OutputRef, Service, Type } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
 import { TranslocoService } from '@jsverse/transloco';
 import { DialogComponent, DialogSize } from '@shared/components/dialog/dialog.component';
@@ -10,6 +10,11 @@ export type DialogContentWithResult<TResult> = DialogContent & { readonly result
 export interface DialogOptions {
   readonly titleKey?: string;
   readonly size?: DialogSize;
+  /**
+   * Forwarded to `attachContent`. Applied by change detection, which has not run by the time
+   * `onOpened` fires — content must read these in `ngOnInit` or an `effect`, not `onOpened`.
+   */
+  readonly bindings?: Binding[];
 }
 
 /**
@@ -47,7 +52,7 @@ export class DialogService {
     this.appRef.attachView(dialogRef.hostView);
     dialogRef.changeDetectorRef.detectChanges();
 
-    const contentRef = dialogRef.instance.attachContent(content);
+    const contentRef = dialogRef.instance.attachContent(content, options?.bindings);
 
     const result$ = new ReplaySubject<TResult>(1);
 

--- a/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.html
+++ b/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,12 @@
+<ng-container *transloco="let t">
+  <p class="mb-6 text-center text-base-content/80">{{ t(messageKey()) }}</p>
+
+  <div class="flex items-center justify-center gap-4">
+    <button type="button" data-testId="confirm" [class]="confirmButtonClass()" (click)="result.emit(true)" (mouseenter)="selectedIndex.set(0)">
+      {{ t(confirmKey()) }}
+    </button>
+    <button type="button" data-testId="cancel" [class]="cancelButtonClass()" (click)="result.emit(false)" (mouseenter)="selectedIndex.set(1)">
+      {{ t(cancelKey()) }}
+    </button>
+  </div>
+</ng-container>

--- a/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,0 +1,150 @@
+import { inputBinding, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { getTranslocoModule } from '@domain/test/transloco.testing';
+import { DialogComponent } from '@shared/components/dialog/dialog.component';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+describe('ConfirmDialogComponent', () => {
+  let component: ConfirmDialogComponent;
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfirmDialogComponent, getTranslocoModule()],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
+    fixture.componentRef.setInput('messageKey', 'settings.account.sign_out_warning.message');
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Regression: `confirmKey`/`cancelKey` default to `confirm_dialog.confirm`/`.cancel`. Nothing
+  // catches a missing entry for those keys in `en.json` except actually reading the rendered
+  // label — `toBeTruthy()` on the button passes just as well for the untranslated key string.
+  it('should render translated text for the default confirm and cancel labels', () => {
+    const confirmButton = fixture.debugElement.query(By.css('[data-testId=confirm]')).nativeElement as HTMLElement;
+    const cancelButton = fixture.debugElement.query(By.css('[data-testId=cancel]')).nativeElement as HTMLElement;
+
+    expect(confirmButton.textContent.trim()).toBe('Confirm');
+    expect(confirmButton.textContent.trim()).not.toBe('confirm_dialog.confirm');
+    expect(cancelButton.textContent.trim()).toBe('Cancel');
+    expect(cancelButton.textContent.trim()).not.toBe('confirm_dialog.cancel');
+  });
+
+  it('should emit true when confirmed', () => {
+    const emitted: boolean[] = [];
+    component.result.subscribe(value => {
+      emitted.push(value);
+    });
+
+    (fixture.debugElement.query(By.css('[data-testId=confirm]')).nativeElement as HTMLElement).click();
+
+    expect(emitted).toEqual([true]);
+  });
+
+  it('should emit false when cancelled', () => {
+    const emitted: boolean[] = [];
+    component.result.subscribe(value => {
+      emitted.push(value);
+    });
+
+    (fixture.debugElement.query(By.css('[data-testId=cancel]')).nativeElement as HTMLElement).click();
+
+    expect(emitted).toEqual([false]);
+  });
+
+  it('should emit false on the cancel input command', async () => {
+    const emitted: boolean[] = [];
+    component.result.subscribe(value => {
+      emitted.push(value);
+    });
+
+    await component.getInputHandlers().cancel?.();
+
+    expect(emitted).toEqual([false]);
+  });
+
+  // Selection is decided in ngOnInit, so these build their own fixture with the inputs set before
+  // the first change detection — the order the real dialog produces, and the order that broke when
+  // this was read from `onOpened` instead.
+  const createWith = (inputs: Record<string, unknown>): ComponentFixture<ConfirmDialogComponent> => {
+    const created = TestBed.createComponent(ConfirmDialogComponent);
+    created.componentRef.setInput('messageKey', 'settings.account.sign_out_warning.message');
+    for (const [name, value] of Object.entries(inputs)) created.componentRef.setInput(name, value);
+    created.detectChanges();
+    return created;
+  };
+
+  const buttonIn = (target: ComponentFixture<ConfirmDialogComponent>, testId: string) =>
+    target.debugElement.query(By.css(`[data-testId=${testId}]`)).nativeElement as HTMLElement;
+
+  // Selection is emphasis — solid when selected, `btn-soft` when not — so that neither button has
+  // to borrow the other's colour to show it is selected.
+  it('should default to selecting confirm', () => {
+    const created = createWith({});
+
+    expect(buttonIn(created, 'confirm').classList).toContain('btn-primary');
+    expect(buttonIn(created, 'confirm').classList).not.toContain('btn-soft');
+  });
+
+  it('should open on the button the caller nominated', () => {
+    const created = createWith({ appearance: 'error', defaultButton: 'cancel' });
+
+    expect(buttonIn(created, 'cancel').classList).toContain('btn-accent');
+    expect(buttonIn(created, 'cancel').classList).not.toContain('btn-soft');
+
+    // Unselected, but still visibly the destructive one — and never wearing cancel's colour.
+    expect(buttonIn(created, 'confirm').classList).toContain('btn-error');
+    expect(buttonIn(created, 'confirm').classList).toContain('btn-soft');
+    expect(buttonIn(created, 'confirm').classList).not.toContain('btn-accent');
+  });
+
+  // Appearance and default selection are independent: a red confirm button is not on its own a
+  // reason to move the selection, so a caller that wants cancel selected has to say so.
+  it('should keep confirm selected for a destructive appearance that did not ask otherwise', () => {
+    const created = createWith({ appearance: 'error' });
+
+    expect(buttonIn(created, 'confirm').classList).not.toContain('btn-soft');
+  });
+
+  // The path the app actually takes: `DialogService` creates the content with `inputBinding`s and
+  // opens it, and change detection applies those bindings. Reading `defaultButton` from `onOpened`
+  // passed every isolated test above and still ignored the caller here, because `open()` runs
+  // before the content's first change detection.
+  it('should honour a nominated default button when opened as real dialog content', () => {
+    const dialogFixture = TestBed.createComponent(DialogComponent);
+    dialogFixture.detectChanges();
+
+    dialogFixture.componentInstance.attachContent(ConfirmDialogComponent, [
+      inputBinding('messageKey', () => 'settings.account.sign_out_warning.message'),
+      inputBinding('appearance', () => 'error'),
+      inputBinding('defaultButton', () => 'cancel'),
+    ]);
+    dialogFixture.componentInstance.open();
+    dialogFixture.detectChanges();
+
+    const cancelButton = (dialogFixture.nativeElement as HTMLElement).querySelector<HTMLElement>('[data-testId=cancel]');
+
+    expect(cancelButton?.classList).toContain('btn-accent');
+    expect(cancelButton?.classList).not.toContain('btn-soft');
+  });
+
+  it('should activate the selected button on confirm', async () => {
+    const emitted: boolean[] = [];
+    component.result.subscribe(value => {
+      emitted.push(value);
+    });
+
+    await component.getInputHandlers().moveRight?.();
+    await component.getInputHandlers().confirm?.();
+
+    expect(emitted).toEqual([false]);
+  });
+});

--- a/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.ts
+++ b/frontend/src/app/shared/ui/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, computed, input, OnInit, output, signal } from '@angular/core';
+import { TranslocoDirective } from '@jsverse/transloco';
+import { DialogContentWithResult } from '@services/dialog.service';
+import { InputLayer } from '@services/input-manager.service';
+import { listNavigation } from '@services/list-navigation';
+import { AH_DIALOG_CONTENT } from '@shared/components/dialog/dialog.content';
+
+export type ConfirmAppearance = 'primary' | 'error';
+export type ConfirmButtonKey = 'confirm' | 'cancel';
+
+interface ConfirmButton {
+  key: ConfirmButtonKey;
+  value: boolean;
+}
+
+/**
+ * Colour carries meaning, emphasis carries selection: each button keeps its own hue in both states
+ * and goes from `btn-soft` to solid when selected. Selection cannot be primary-vs-default here, as
+ * it is for a row of equal actions — that would leave cancel wearing the confirm colour when
+ * selected, and confirm dropping its danger colour when it is not.
+ *
+ * Cancel is `accent` (a hue-neutral grey at 43% lightness) rather than `neutral`, which sits at 30%
+ * against a 20% base and is what made the previous `btn-active` highlight invisible.
+ *
+ * The whole class list per state, not just the differing part — Tailwind only emits classes spelled
+ * out in source, as `SIZE_CLASSES` notes in `dialog.component.ts`.
+ */
+const CONFIRM_BUTTON_CLASSES: Record<ConfirmAppearance, { selected: string; unselected: string }> = {
+  primary: { selected: 'btn btn-primary', unselected: 'btn btn-soft btn-primary' },
+  error: { selected: 'btn btn-error', unselected: 'btn btn-soft btn-error' },
+};
+
+const CANCEL_BUTTON_CLASSES = { selected: 'btn btn-accent', unselected: 'btn btn-soft btn-accent' } as const;
+
+/**
+ * A reusable confirm/cancel prompt, opened through `ConfirmDialogService` rather than instantiated
+ * directly — that service is the public API and always yields a decision, including when the
+ * dialog is dismissed without one. Sign-out-while-anonymous is its first caller.
+ */
+@Component({
+  selector: 'ah-confirm-dialog',
+  imports: [TranslocoDirective],
+  templateUrl: './confirm-dialog.component.html',
+  providers: [
+    {
+      provide: AH_DIALOG_CONTENT,
+      useExisting: ConfirmDialogComponent,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfirmDialogComponent implements DialogContentWithResult<boolean>, OnInit {
+  public readonly messageKey = input.required<string>();
+  public readonly confirmKey = input('confirm_dialog.confirm');
+  public readonly cancelKey = input('confirm_dialog.cancel');
+  public readonly appearance = input<ConfirmAppearance>('primary');
+
+  /**
+   * Which button is selected when the dialog opens. Confirm is the usual answer — the caller is
+   * asking because it expects a yes — so a destructive prompt has to ask for `'cancel'` rather than
+   * getting it implicitly from `appearance`: the two are independent, and a red confirm button is
+   * not by itself a reason to move the selection.
+   */
+  public readonly defaultButton = input<ConfirmButtonKey>('confirm');
+
+  public readonly result = output<boolean>();
+
+  private readonly buttons = signal<ConfirmButton[]>([
+    { key: 'confirm', value: true },
+    { key: 'cancel', value: false },
+  ]);
+
+  private readonly navigation = listNavigation({
+    items: this.buttons,
+    onConfirm: button => {
+      this.result.emit(button.value);
+    },
+    orientation: 'horizontal',
+  });
+  protected readonly selectedIndex = this.navigation.selectedIndex;
+
+  protected readonly confirmButtonClass = computed(() => {
+    const classes = CONFIRM_BUTTON_CLASSES[this.appearance()];
+    return this.selectedIndex() === 0 ? classes.selected : classes.unselected;
+  });
+  protected readonly cancelButtonClass = computed(() => (this.selectedIndex() === 1 ? CANCEL_BUTTON_CLASSES.selected : CANCEL_BUTTON_CLASSES.unselected));
+
+  /**
+   * Not `onOpened`: that fires before this component's first change detection, so `defaultButton`
+   * would still read as its declared default and a caller asking for cancel would be ignored.
+   * Inputs are applied by the time `ngOnInit` runs.
+   */
+  public ngOnInit(): void {
+    const index = this.buttons().findIndex(button => button.key === this.defaultButton());
+    this.selectedIndex.set(index === -1 ? 0 : index);
+  }
+
+  public getInputHandlers: () => InputLayer = () => ({
+    ...this.navigation.handlers,
+    cancel: () => {
+      this.result.emit(false);
+    },
+  });
+}

--- a/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.html
+++ b/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.html
@@ -1,0 +1,44 @@
+<ng-container *transloco="let t; prefix: 'auth.credentials_form'">
+  <form #form [formRoot]="signInForm">
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t("legend") }}</legend>
+
+      <label class="floating-label mt-2">
+        <input type="email" class="validator input w-full" ahFocusTrap [formField]="signInForm.email" />
+        <span>{{ t("email") }}</span>
+      </label>
+
+      <label class="floating-label mt-4">
+        <input type="text" class="input w-full" [formField]="signInForm.username" />
+        <span>{{ t("username") }}</span>
+      </label>
+
+      <label class="floating-label mt-4">
+        <input type="password" class="input w-full" [formField]="signInForm.password" />
+        <span>{{ t("password") }}</span>
+      </label>
+    </fieldset>
+
+    @if (signInForm().errors()[0]; as err) {
+      <div role="alert" class="mt-4 alert alert-soft alert-error">
+        @if (err.message; as message) {
+          <span>{{ message }}</span>
+        } @else {
+          <span>{{ t(`errors.${err.kind}`) }}</span>
+        }
+      </div>
+    }
+
+    <div class="mt-6 flex items-center justify-around gap-4">
+      <button type="submit" class="btn btn-primary" [disabled]="signInForm().invalid() || signInForm().submitting()">
+        @if (signInForm().submitting()) {
+          <span class="loading loading-sm loading-spinner"></span>
+        }
+        {{ t(submitKey()) }}
+      </button>
+      <button type="button" class="btn btn-active" [disabled]="signInForm().submitting()" (click)="dismiss()">
+        {{ t(dismissKey()) }}
+      </button>
+    </div>
+  </form>
+</ng-container>

--- a/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.spec.ts
@@ -1,0 +1,149 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { getTranslocoModule } from '@domain/test/transloco.testing';
+import { AuthService, User } from '@services/auth.service';
+import { Subject } from 'rxjs';
+import { vi } from 'vitest';
+import { CredentialsFormComponent } from './credentials-form.component';
+
+describe('CredentialsFormComponent', () => {
+  let component: CredentialsFormComponent;
+  let fixture: ComponentFixture<CredentialsFormComponent>;
+  let signIn$: Subject<User>;
+  let signIn: ReturnType<typeof vi.fn>;
+
+  const setInputValue = (type: string, value: string) => {
+    const input = fixture.debugElement.query(By.css(`input[type=${type}]`)).nativeElement as HTMLInputElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  };
+
+  const fillValidCredentials = () => {
+    setInputValue('email', 'a@example.com');
+    setInputValue('text', 'a');
+    setInputValue('password', 'P@ssw0rd');
+  };
+
+  const submitButton = () => fixture.debugElement.query(By.css('.btn-primary')).nativeElement as HTMLButtonElement;
+  const dismissButton = () => fixture.debugElement.query(By.css('.btn-active')).nativeElement as HTMLButtonElement;
+
+  beforeEach(async () => {
+    signIn$ = new Subject<User>();
+    signIn = vi.fn(() => signIn$);
+
+    await TestBed.configureTestingModule({
+      imports: [CredentialsFormComponent, getTranslocoModule()],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: AuthService,
+          useValue: { signIn },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CredentialsFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should disable submit while the form is invalid', () => {
+    expect(submitButton().disabled).toBe(true);
+
+    fillValidCredentials();
+
+    expect(submitButton().disabled).toBe(false);
+  });
+
+  it('should emit a User when submitting valid credentials', async () => {
+    const emitted: (User | undefined)[] = [];
+    component.result.subscribe(user => {
+      emitted.push(user);
+    });
+
+    fillValidCredentials();
+    submitButton().click();
+    // `FormRoot` runs the submission through the forms package's own async `submit()`, which
+    // resolves validity before calling `action` — a microtask beyond the click.
+    await fixture.whenStable();
+    signIn$.next({ isAnonymous: false, email: 'a@example.com', userName: 'a' });
+    // A second hop: `next()` resolves the promise `action` is awaiting, and `result.emit` runs
+    // once that resumes, not synchronously with the call above.
+    await fixture.whenStable();
+
+    expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
+    expect(emitted).toEqual([{ isAnonymous: false, email: 'a@example.com', userName: 'a' } satisfies User]);
+  });
+
+  it('should show a translated message on 403', async () => {
+    fillValidCredentials();
+    submitButton().click();
+    await fixture.whenStable();
+    signIn$.error(new HttpErrorResponse({ status: 403 }));
+
+    const alert = await vi.waitFor(() => {
+      fixture.detectChanges();
+      return fixture.debugElement.query(By.css('.alert')).nativeElement as HTMLElement;
+    });
+
+    expect(alert.textContent).toContain('incorrect');
+  });
+
+  it('should render IdentityResult descriptions on 400', async () => {
+    fillValidCredentials();
+    submitButton().click();
+    await fixture.whenStable();
+    signIn$.error(
+      new HttpErrorResponse({
+        status: 400,
+        error: { succeeded: false, errors: [{ code: 'password_short', description: 'Passwords must be at least 6 characters.' }] },
+      }),
+    );
+
+    const alert = await vi.waitFor(() => {
+      fixture.detectChanges();
+      return fixture.debugElement.query(By.css('.alert')).nativeElement as HTMLElement;
+    });
+
+    expect(alert.textContent).toContain('Passwords must be at least 6 characters.');
+  });
+
+  it('should emit undefined when dismissed', () => {
+    const emitted: (User | undefined)[] = [];
+    component.result.subscribe(user => {
+      emitted.push(user);
+    });
+
+    dismissButton().click();
+
+    expect(emitted).toEqual([undefined]);
+  });
+
+  describe('getInputHandlers', () => {
+    it('should dismiss on cancel', async () => {
+      const emitted: (User | undefined)[] = [];
+      component.result.subscribe(user => {
+        emitted.push(user);
+      });
+
+      await component.getInputHandlers().cancel?.();
+
+      expect(emitted).toEqual([undefined]);
+    });
+
+    it('should submit through requestSubmit on confirm', async () => {
+      fillValidCredentials();
+
+      await component.getInputHandlers().confirm?.();
+
+      expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
+    });
+  });
+});

--- a/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.ts
+++ b/frontend/src/app/shared/ui/components/credentials-form/credentials-form.component.ts
@@ -1,0 +1,91 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, input, output, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { email, form, FormField, FormRoot, required } from '@angular/forms/signals';
+import { TranslocoDirective } from '@jsverse/transloco';
+import { AuthService, Credentials, User } from '@services/auth.service';
+import { DialogContentWithResult, DialogOptions } from '@services/dialog.service';
+import { InputLayer } from '@services/input-manager.service';
+import { AH_DIALOG_CONTENT } from '@shared/components/dialog/dialog.content';
+import { FocusTrapDirective } from '@shared/directives/focus-trap.directive';
+import { firstValueFrom } from 'rxjs';
+import { toValidationError } from './credentials-form.errors';
+
+/**
+ * The dialog title when the form is opened directly (bind an anonymous account, sign in from
+ * Settings). `SignInComponent` never uses this — it opens the form as a view inside its own
+ * already-titled dialog.
+ */
+export const CREDENTIALS_DIALOG_OPTIONS = { titleKey: 'auth.credentials_form.title', size: 's' } as const satisfies DialogOptions;
+
+/**
+ * The email/username/password sign-in-or-register-or-upgrade form, extracted from `SignInComponent`
+ * so `DialogService` can open it on its own — both account-section entry points need that, since
+ * neither shows the choice view. Angular's first Signal Form in this codebase: submission is
+ * declarative (`[formRoot]` + `submission.action`), not an imperative `submit()` call.
+ */
+@Component({
+  selector: 'ah-credentials-form',
+  imports: [FormField, FormRoot, TranslocoDirective, FocusTrapDirective],
+  templateUrl: './credentials-form.component.html',
+  providers: [
+    {
+      provide: AH_DIALOG_CONTENT,
+      useExisting: CredentialsFormComponent,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CredentialsFormComponent implements DialogContentWithResult<User | undefined> {
+  private readonly auth = inject(AuthService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Relative to the `auth.credentials_form` prefix, so a host can relabel the secondary button. */
+  public readonly submitKey = input('submit');
+  public readonly dismissKey = input('cancel');
+
+  /** `undefined` on dismissal — `DialogService` tears down on any emission, so a standalone form
+   * closes itself on either outcome, while `SignInComponent` maps `undefined` back to its choice
+   * view. No further plumbing is needed for either host. */
+  public readonly result = output<User | undefined>();
+
+  private readonly formElement = viewChild.required<ElementRef<HTMLFormElement>>('form');
+
+  protected readonly credentials = signal<Credentials>({ email: '', username: '', password: '' });
+
+  protected readonly signInForm = form(
+    this.credentials,
+    path => {
+      required(path.email);
+      email(path.email);
+      required(path.username);
+      required(path.password);
+    },
+    {
+      submission: {
+        action: async () => {
+          try {
+            this.result.emit(await firstValueFrom(this.auth.signIn(this.credentials()).pipe(takeUntilDestroyed(this.destroyRef))));
+            return undefined;
+          } catch (err: unknown) {
+            return toValidationError(err);
+          }
+        },
+      },
+    },
+  );
+
+  /** `confirm` submits through the same path a button click does, rather than restating it — the
+   * keyboard's only route in, since `InputManagerService` already claims `Enter` inside text inputs. */
+  public getInputHandlers: () => InputLayer = () => ({
+    cancel: () => {
+      this.dismiss();
+    },
+    confirm: () => {
+      this.formElement().nativeElement.requestSubmit();
+    },
+  });
+
+  protected dismiss(): void {
+    this.result.emit(undefined);
+  }
+}

--- a/frontend/src/app/shared/ui/components/credentials-form/credentials-form.errors.ts
+++ b/frontend/src/app/shared/ui/components/credentials-form/credentials-form.errors.ts
@@ -1,0 +1,33 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ValidationError } from '@angular/forms/signals';
+
+interface IdentityError {
+  code?: string;
+  description?: string;
+}
+
+interface IdentityResult {
+  succeeded: boolean;
+  errors: IdentityError[];
+}
+
+/**
+ * Adapts `AuthService.signIn()`'s failure modes to a form-level `ValidationError`, so the
+ * submission `action` can hand it straight back to the field tree. The two paths the alert has
+ * always had survive unchanged: a translated key for a known status, or the server's own text
+ * for a `400`. `kind` alone (no `message`) means "translate `errors.<kind>`" — the template reads
+ * it that way.
+ */
+export function toValidationError(err: unknown): ValidationError {
+  if (err instanceof HttpErrorResponse) {
+    if (err.status === 403) return { kind: 'wrong_password' };
+
+    if (err.status === 400) {
+      const body = err.error as IdentityResult | null;
+      const descriptions = (body?.errors ?? []).map(e => e.description).filter((d): d is string => Boolean(d));
+      if (descriptions.length > 0) return { kind: 'server', message: descriptions.join(' ') };
+    }
+  }
+
+  return { kind: 'generic' };
+}

--- a/frontend/src/app/shared/ui/components/dialog/dialog.component.html
+++ b/frontend/src/app/shared/ui/components/dialog/dialog.component.html
@@ -2,7 +2,7 @@
   <div [class]="boxClasses()">
     <ah-svg name="modal-border" class="absolute inset-x-0 top-0 -z-50 aspect-512/67" />
     <h1 class="w-fit place-self-center text-3xl">
-      {{ title() }}
+      {{ displayedTitle() }}
       <div class="mt-1 mb-4 h-2 w-full border-y border-primary-content"></div>
     </h1>
     <div>

--- a/frontend/src/app/shared/ui/components/dialog/dialog.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/dialog/dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { InputLayer, InputManagerService } from '@services/input-manager.service';
 import { MockInstance, vi } from 'vitest';
@@ -20,10 +20,13 @@ import { AH_DIALOG_CONTENT, DialogContent } from './dialog.content';
 })
 class TestContentComponent implements DialogContent {
   public opened = false;
+  public readonly ownTitle = signal<string | undefined>(undefined);
 
   public onOpened = () => {
     this.opened = true;
   };
+
+  public getTitle = () => this.ownTitle();
 
   public getInputHandlers = () => ({
     confirm: () => {
@@ -136,6 +139,28 @@ describe('DialogComponent', () => {
       expect(box.classList.contains('modal-box')).toBe(true);
     });
   }
+
+  // The title is pulled from content, not pushed by it, so a view swap inside the content renames
+  // the dialog without the content holding a reference to it.
+  it('should take its heading from the content, and follow the content when that changes', () => {
+    fixture.componentRef.setInput('title', 'Settings');
+    const contentRef = component.attachContent(TestContentComponent);
+    fixture.detectChanges();
+
+    const heading = () => (fixture.debugElement.query(By.css('h1')).nativeElement as HTMLElement).textContent.trim();
+
+    expect(heading()).toBe('Settings');
+
+    contentRef.instance.ownTitle.set('Your Account');
+    fixture.detectChanges();
+
+    expect(heading()).toBe('Your Account');
+
+    contentRef.instance.ownTitle.set(undefined);
+    fixture.detectChanges();
+
+    expect(heading()).toBe('Settings');
+  });
 
   it('should prevent the native cancel event so Escape cannot close the dialog on its own', () => {
     const dialogEl = fixture.debugElement.query(By.css('dialog')).nativeElement as HTMLDialogElement;

--- a/frontend/src/app/shared/ui/components/dialog/dialog.component.ts
+++ b/frontend/src/app/shared/ui/components/dialog/dialog.component.ts
@@ -1,4 +1,5 @@
 import {
+  Binding,
   ChangeDetectionStrategy,
   Component,
   ComponentRef,
@@ -9,6 +10,7 @@ import {
   input,
   OnDestroy,
   output,
+  signal,
   Type,
   viewChild,
   ViewContainerRef,
@@ -59,6 +61,13 @@ export class DialogComponent implements OnDestroy {
   protected readonly boxClasses = computed(() => SIZE_CLASSES[this.size()]);
 
   /**
+   * Asked of the content rather than pushed by it, so a view swap renames the dialog on its own —
+   * the same pull the input layer does. A computed, so it has to read `dynamicContent` through a
+   * signal or attaching content after this first evaluates would never re-run it.
+   */
+  protected readonly displayedTitle = computed(() => this.resolveContent()?.getTitle?.() ?? this.title());
+
+  /**
    * Fires whenever the underlying `<dialog>` actually closes — via `close()` below, or any other
    * UA-initiated close. The template also prevents the native `cancel` event (Escape), so
    * `InputManagerService`'s layer stays the single source of truth for what Escape does; this
@@ -70,16 +79,16 @@ export class DialogComponent implements OnDestroy {
   private readonly dialog = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
   private readonly projectedContent = contentChild(AH_DIALOG_CONTENT);
   private readonly contentHost = viewChild('contentHost', { read: ViewContainerRef });
-  private dynamicContent: ComponentRef<DialogContent> | undefined;
+  private readonly dynamicContent = signal<ComponentRef<DialogContent> | undefined>(undefined);
   private inputLayer: LayerRef | undefined;
 
   /** Instantiates `type` into the dialog body, replacing content projected via `<ng-content />`. */
-  public attachContent<T extends DialogContent>(type: Type<T>): ComponentRef<T> {
+  public attachContent<T extends DialogContent>(type: Type<T>, bindings?: Binding[]): ComponentRef<T> {
     const host = this.contentHost();
     if (!host) throw new Error('Dialog content host is not yet initialized');
 
-    const ref = host.createComponent(type);
-    this.dynamicContent = ref;
+    const ref = bindings ? host.createComponent(type, { bindings }) : host.createComponent(type);
+    this.dynamicContent.set(ref);
     return ref;
   }
 
@@ -117,6 +126,6 @@ export class DialogComponent implements OnDestroy {
   }
 
   private resolveContent(): DialogContent | undefined {
-    return this.dynamicContent?.instance ?? this.projectedContent();
+    return this.dynamicContent()?.instance ?? this.projectedContent();
   }
 }

--- a/frontend/src/app/shared/ui/components/dialog/dialog.content.ts
+++ b/frontend/src/app/shared/ui/components/dialog/dialog.content.ts
@@ -2,9 +2,25 @@
 import { InputLayer } from '@services/input-manager.service';
 
 export interface DialogContent {
+  /**
+   * Fires when the dialog opens — **before** the content's first change detection, so its inputs
+   * are not applied yet: anything passed through `DialogOptions.bindings` still reads as its
+   * declared default here. Initialize from inputs in `ngOnInit` or an `effect` instead.
+   *
+   * What this hook is for is content that outlives a single open — projected content is created
+   * once and reopened many times, so per-open state (a view swap, a selection) has to be reset
+   * somewhere `ngOnInit` will not run again.
+   */
   onOpened?: () => void;
   onClosed?: () => void;
 
   getInputHandlers?: () => InputLayer;
+
+  /**
+   * The heading this content wants, or `undefined` to leave the dialog's own `title` input alone.
+   * Read reactively, on the same principle as `getInputHandlers`: content that swaps views renames
+   * the dialog by returning a different value, rather than pushing a title into it.
+   */
+  getTitle?: () => string | undefined;
 }
 export const AH_DIALOG_CONTENT = new InjectionToken<DialogContent>('AH_DIALOG_CONTENT');

--- a/frontend/src/app/shared/ui/components/settings/account/account.component.html
+++ b/frontend/src/app/shared/ui/components/settings/account/account.component.html
@@ -1,0 +1,39 @@
+<ng-container *transloco="let t; prefix: 'settings.account'">
+  @switch (state()) {
+    @case ("anonymous") {
+      <p>
+        {{ t("anonymous.name_label") }}: <span class="break-all">{{ user()?.userName }}</span>
+      </p>
+      <p class="mt-2">{{ t("anonymous.state") }}</p>
+      <p class="mt-1 text-base-content/70">{{ t("anonymous.detail") }}</p>
+    }
+    @case ("permanent") {
+      <p>{{ t("permanent.name_label") }}: {{ user()?.userName }}</p>
+      <p>{{ t("permanent.email_label") }}: {{ user()?.email }}</p>
+      <p class="mt-2">{{ t("permanent.state") }}</p>
+      <p class="mt-1 text-base-content/70">{{ t("permanent.detail") }}</p>
+    }
+    @case ("signed_out") {
+      <p>{{ t("signed_out.state") }}</p>
+      <p class="mt-1 text-base-content/70">{{ t("signed_out.detail") }}</p>
+    }
+    @default {
+      <!-- `state()` is exhaustive over the three cases above; kept for the compile-time check. -->
+    }
+  }
+
+  <div class="mt-6 flex items-center justify-center gap-4">
+    @for (action of actions(); track action.key) {
+      <button
+        type="button"
+        class="btn"
+        [class.btn-primary]="$index === selectedIndex()"
+        [attr.data-testId]="action.key"
+        (click)="action.process()"
+        (mouseenter)="selectedIndex.set($index)"
+      >
+        {{ t(action.labelKey) }}
+      </button>
+    }
+  </div>
+</ng-container>

--- a/frontend/src/app/shared/ui/components/settings/account/account.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/settings/account/account.component.spec.ts
@@ -1,0 +1,150 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { getTranslocoModule } from '@domain/test/transloco.testing';
+import { AuthService, User } from '@services/auth.service';
+import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { DialogService } from '@services/dialog.service';
+import { CREDENTIALS_DIALOG_OPTIONS, CredentialsFormComponent } from '@shared/components/credentials-form/credentials-form.component';
+import { BehaviorSubject, EMPTY, of } from 'rxjs';
+import { vi } from 'vitest';
+import { AccountComponent } from './account.component';
+
+describe('AccountComponent', () => {
+  let component: AccountComponent;
+  let fixture: ComponentFixture<AccountComponent>;
+  let user$: BehaviorSubject<User | undefined>;
+  let logout: ReturnType<typeof vi.fn>;
+  let openDialog: ReturnType<typeof vi.fn>;
+  let confirm: ReturnType<typeof vi.fn>;
+
+  const click = (testId: string) => {
+    (fixture.debugElement.query(By.css(`[data-testId=${testId}]`)).nativeElement as HTMLElement).click();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    user$ = new BehaviorSubject<User | undefined>(undefined);
+    logout = vi.fn(() => of(undefined));
+    openDialog = vi.fn(() => EMPTY);
+    confirm = vi.fn(() => of(false));
+
+    await TestBed.configureTestingModule({
+      imports: [AccountComponent, getTranslocoModule()],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AuthService, useValue: { currentUser: user$, logout } },
+        { provide: DialogService, useValue: { open: openDialog } },
+        { provide: ConfirmDialogService, useValue: { confirm } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the signed-out state with a sign-in action', () => {
+    expect(fixture.debugElement.query(By.css('[data-testId=sign_in]'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('[data-testId=sign_out]'))).toBeFalsy();
+  });
+
+  it('should show the anonymous state with the raw userName and an upgrade action', () => {
+    user$.next({ isAnonymous: true, email: null, userName: 'guid-123' });
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('guid-123');
+    expect(fixture.debugElement.query(By.css('[data-testId=upgrade]'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('[data-testId=sign_out]'))).toBeTruthy();
+  });
+
+  it('should show the permanent state with the registered name and email', () => {
+    user$.next({ isAnonymous: false, email: 'a@example.com', userName: 'Alice' });
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent;
+
+    expect(text).toContain('Alice');
+    expect(text).toContain('a@example.com');
+    expect(fixture.debugElement.query(By.css('[data-testId=upgrade]'))).toBeFalsy();
+    expect(fixture.debugElement.query(By.css('[data-testId=sign_out]'))).toBeTruthy();
+  });
+
+  it('should sign out immediately when permanent', () => {
+    user$.next({ isAnonymous: false, email: 'a@example.com', userName: 'Alice' });
+    fixture.detectChanges();
+
+    click('sign_out');
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(logout).toHaveBeenCalledWith();
+  });
+
+  it('should confirm before signing out an anonymous account, and leave the session on cancel', () => {
+    confirm.mockReturnValue(of(false));
+    user$.next({ isAnonymous: true, email: null, userName: 'guid-123' });
+    fixture.detectChanges();
+
+    click('sign_out');
+
+    // Destructive, and opening on cancel — the appearance alone no longer decides that.
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ appearance: 'error', defaultButton: 'cancel' }));
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it('should sign out an anonymous account once the warning is confirmed', () => {
+    confirm.mockReturnValue(of(true));
+    user$.next({ isAnonymous: true, email: null, userName: 'guid-123' });
+    fixture.detectChanges();
+
+    click('sign_out');
+
+    expect(logout).toHaveBeenCalledWith();
+  });
+
+  it('should open the credentials form to upgrade an anonymous account, and change nothing when it is dismissed', () => {
+    user$.next({ isAnonymous: true, email: null, userName: 'guid-123' });
+    fixture.detectChanges();
+
+    click('upgrade');
+
+    expect(openDialog).toHaveBeenCalledWith(CredentialsFormComponent, CREDENTIALS_DIALOG_OPTIONS);
+    // `EMPTY` from the mock stands in for a dismissal — nothing here subscribes to the result, and
+    // `currentUser` is untouched, so the anonymous session is exactly as it was.
+    expect(user$.value).toEqual({ isAnonymous: true, email: null, userName: 'guid-123' } satisfies User);
+  });
+
+  it('should open the credentials form to sign in when signed out', () => {
+    click('sign_in');
+
+    expect(openDialog).toHaveBeenCalledWith(CredentialsFormComponent, CREDENTIALS_DIALOG_OPTIONS);
+  });
+
+  it('should emit back on the back action', () => {
+    let emittedCount = 0;
+    component.back.subscribe(() => {
+      emittedCount++;
+    });
+
+    click('back');
+
+    expect(emittedCount).toBe(1);
+  });
+
+  describe('getInputHandlers', () => {
+    it('should emit back on cancel', async () => {
+      let emittedCount = 0;
+      component.back.subscribe(() => {
+        emittedCount++;
+      });
+
+      await component.getInputHandlers().cancel?.();
+
+      expect(emittedCount).toBe(1);
+    });
+  });
+});

--- a/frontend/src/app/shared/ui/components/settings/account/account.component.ts
+++ b/frontend/src/app/shared/ui/components/settings/account/account.component.ts
@@ -1,0 +1,158 @@
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, output, Signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { TranslocoDirective } from '@jsverse/transloco';
+import { AuthService } from '@services/auth.service';
+import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { DialogService } from '@services/dialog.service';
+import { InputLayer } from '@services/input-manager.service';
+import { listNavigation } from '@services/list-navigation';
+import { CREDENTIALS_DIALOG_OPTIONS, CredentialsFormComponent } from '@shared/components/credentials-form/credentials-form.component';
+import { filter, switchMap } from 'rxjs';
+
+type AccountState = 'anonymous' | 'permanent' | 'signed_out';
+
+interface AccountAction {
+  key: 'upgrade' | 'sign_out' | 'sign_in' | 'back';
+  /** Relative to the `settings.account` prefix — `back` lives there directly, the rest under the
+   * current state's own sub-key. */
+  labelKey: string;
+  process: () => void;
+}
+
+/**
+ * A view inside the settings dialog, not dialog content of its own — reached by confirming the
+ * "Account" row in `SettingsComponent`. Shows who is signed in and offers that state's actions.
+ */
+@Component({
+  selector: 'ah-account',
+  imports: [TranslocoDirective],
+  templateUrl: './account.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AccountComponent {
+  private readonly auth = inject(AuthService);
+  private readonly dialog = inject(DialogService);
+  private readonly confirmDialog = inject(ConfirmDialogService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public readonly back = output();
+
+  protected readonly user = toSignal(this.auth.currentUser);
+  protected readonly state: Signal<AccountState> = computed(() => {
+    const user = this.user();
+    if (user === undefined) return 'signed_out';
+    return user.isAnonymous ? 'anonymous' : 'permanent';
+  });
+
+  protected readonly actions = computed<AccountAction[]>(() => {
+    switch (this.state()) {
+      case 'anonymous':
+        return [
+          {
+            key: 'upgrade',
+            labelKey: 'anonymous.upgrade',
+            process: () => {
+              this.openCredentialsForm();
+            },
+          },
+          {
+            key: 'sign_out',
+            labelKey: 'anonymous.sign_out',
+            process: () => {
+              this.signOutAnonymous();
+            },
+          },
+          {
+            key: 'back',
+            labelKey: 'back',
+            process: () => {
+              this.back.emit();
+            },
+          },
+        ];
+      case 'permanent':
+        return [
+          {
+            key: 'sign_out',
+            labelKey: 'permanent.sign_out',
+            process: () => {
+              this.signOutPermanent();
+            },
+          },
+          {
+            key: 'back',
+            labelKey: 'back',
+            process: () => {
+              this.back.emit();
+            },
+          },
+        ];
+      case 'signed_out':
+        return [
+          {
+            key: 'sign_in',
+            labelKey: 'signed_out.sign_in',
+            process: () => {
+              this.openCredentialsForm();
+            },
+          },
+          {
+            key: 'back',
+            labelKey: 'back',
+            process: () => {
+              this.back.emit();
+            },
+          },
+        ];
+    }
+  });
+
+  private readonly navigation = listNavigation({
+    items: this.actions,
+    onConfirm: action => {
+      action.process();
+    },
+    orientation: 'horizontal',
+  });
+  protected readonly selectedIndex = this.navigation.selectedIndex;
+
+  public getInputHandlers: () => InputLayer = () => ({
+    ...this.navigation.handlers,
+    cancel: () => {
+      this.back.emit();
+    },
+  });
+
+  /**
+   * Stacked over the settings dialog, not a replacement for it. No result subscription: `signIn()`
+   * refreshes `AuthService.currentUser` itself, so `state` and `user` re-derive on their own —
+   * dismissing the form changes nothing, which is the whole point for an anonymous session.
+   */
+  protected openCredentialsForm(): void {
+    this.dialog.open(CredentialsFormComponent, CREDENTIALS_DIALOG_OPTIONS);
+  }
+
+  protected signOutPermanent(): void {
+    this.auth.logout().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+  }
+
+  /** Logging out deletes an anonymous account for good, so it is warned rather than immediate. */
+  protected signOutAnonymous(): void {
+    this.confirmDialog
+      .confirm({
+        titleKey: 'settings.account.sign_out_warning.title',
+        messageKey: 'settings.account.sign_out_warning.message',
+        confirmKey: 'settings.account.sign_out_warning.confirm',
+        cancelKey: 'settings.account.sign_out_warning.cancel',
+        appearance: 'error',
+        // Deleting the account for good is never one Enter away from a dialog that just appeared.
+        defaultButton: 'cancel',
+      })
+      .pipe(
+        filter(Boolean),
+        switchMap(() => this.auth.logout()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+}

--- a/frontend/src/app/shared/ui/components/settings/account/account.stories.ts
+++ b/frontend/src/app/shared/ui/components/settings/account/account.stories.ts
@@ -1,0 +1,60 @@
+import { AuthService, User } from '@services/auth.service';
+import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { DialogService } from '@services/dialog.service';
+import { DialogComponent } from '@shared/components/dialog/dialog.component';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { NEVER, of } from 'rxjs';
+import { AccountComponent } from './account.component';
+
+const withUser = (user: User | undefined) =>
+  moduleMetadata({
+    providers: [
+      {
+        provide: AuthService,
+        useValue: { currentUser: of(user) },
+      },
+    ],
+  });
+
+const meta: Meta<AccountComponent> = {
+  component: AccountComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [DialogComponent],
+      providers: [
+        // Requests never resolve — the stories only exercise the three static states, not a real
+        // sign-out or upgrade.
+        { provide: DialogService, useValue: { open: () => NEVER } },
+        { provide: ConfirmDialogService, useValue: { confirm: () => NEVER } },
+      ],
+    }),
+  ],
+  parameters: {
+    // The dialog is `position: fixed` and covers the canvas, so story padding would only mislead —
+    // this view renders inside the settings dialog's own `size="s"` box, as it does in the app.
+    layout: 'fullscreen',
+  },
+  // The heading is the dialog's, not this component's: `SettingsComponent` renames the dialog when
+  // it switches to this view, so the story hardcodes the name that swap produces.
+  render: () => ({
+    template: `
+      <ah-dialog [isOpen]="true" title="Your Account" size="s">
+        <ah-account />
+      </ah-dialog>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<AccountComponent>;
+
+export const Anonymous: Story = {
+  decorators: [withUser({ isAnonymous: true, email: null, userName: '4139f1ea-4901-4253-a391-021faa001677' })],
+};
+
+export const Permanent: Story = {
+  decorators: [withUser({ isAnonymous: false, email: 'a@example.com', userName: 'Alice' })],
+};
+
+export const SignedOut: Story = {
+  decorators: [withUser(undefined)],
+};

--- a/frontend/src/app/shared/ui/components/settings/settings.component.html
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.html
@@ -1,25 +1,56 @@
 <ng-container *transloco="let t">
-  <div class="text-center text-xl">
-    <ah-setting-item
-      #setting
-      name="Language"
-      tabindex="0"
-      [template]="lang"
-      [currentValue]="settings().lang"
-      [selected]="selectedIndex() === 0"
-      (nextValue)="nextLang()"
-      (prevValue)="prevLang()"
-    />
-  </div>
+  @if (view() === "settings") {
+    <div class="text-center text-xl">
+      <ah-setting-item
+        #setting
+        tabindex="0"
+        [name]="t('settings.language')"
+        [template]="lang"
+        [currentValue]="settings().lang"
+        [selected]="selectedIndex() === 0"
+        (mouseenter)="selectedIndex.set(0)"
+        (nextValue)="nextLang()"
+        (prevValue)="prevLang()"
+      />
 
-  <div class="mt-5 flex items-center justify-center gap-8">
-    <button type="submit" class="btn self-center btn-primary" (click)="applySettings()">
-      {{ t("Apply") }}
-    </button>
-    <button type="reset" class="btn self-center" (click)="discardSettings()">
-      {{ t("Discard") }}
-    </button>
-  </div>
+      <!-- Same two-column grid as `ah-setting-item`'s host, so this label sits in the same column
+           as "Language" instead of against the dialog's left edge. -->
+      <button
+        type="button"
+        class="grid w-full grid-cols-2 gap-8 outline-hidden"
+        data-testId="account-row"
+        [class.text-accent-content]="selectedIndex() === accountRowIndex()"
+        (click)="view.set('account')"
+        (mouseenter)="selectedIndex.set(accountRowIndex())"
+      >
+        <p>{{ t("settings.account.row") }}</p>
+      </button>
+    </div>
+
+    <div class="mt-5 flex items-center justify-center gap-8">
+      <button
+        type="submit"
+        class="btn self-center"
+        [class.btn-primary]="isButtonsRowSelected() && selectedButtonIndex() === 0"
+        (click)="applySettings()"
+        (mouseenter)="selectedIndex.set(buttonsRowIndex()); selectedButtonIndex.set(0)"
+      >
+        {{ t("Apply") }}
+      </button>
+      <button
+        type="reset"
+        class="btn self-center"
+        [class.btn-primary]="isButtonsRowSelected() && selectedButtonIndex() === 1"
+        (click)="discardSettings()"
+        (mouseenter)="selectedIndex.set(buttonsRowIndex()); selectedButtonIndex.set(1)"
+      >
+        {{ t("Discard") }}
+      </button>
+    </div>
+  } @else {
+    <ah-account (back)="view.set('settings')" />
+  }
+
   <ng-template #lang let-lang>
     <span class="w-32">{{ getLangDisplay(lang) }}</span>
   </ng-template>

--- a/frontend/src/app/shared/ui/components/settings/settings.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.spec.ts
@@ -3,10 +3,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { getTranslocoModule } from '@domain/test/transloco.testing';
+import { AuthService } from '@services/auth.service';
 import { SettingsService } from '@services/settings/settings.service';
 import { provideUserPreferencesService, UserPreferences } from '@services/settings/user-preferences.service';
 import { AH_DIALOG_CONTEXT } from '@shared/components/dialog/dialog.context';
+import { of } from 'rxjs';
 import { vi } from 'vitest';
+import { AccountComponent } from './account/account.component';
 import { SettingItemComponent } from './setting-item/setting-item.component';
 import { SettingsComponent } from './settings.component';
 
@@ -27,6 +30,8 @@ describe('SettingsComponent', () => {
         set: {
           providers: [
             provideUserPreferencesService(),
+            // `ah-account` is rendered inside the account view, and needs AuthService to construct.
+            { provide: AuthService, useValue: { currentUser: of(undefined) } },
             {
               provide: AH_DIALOG_CONTEXT,
               useValue: {
@@ -63,17 +68,32 @@ describe('SettingsComponent', () => {
     expect(langDisplay()).toBe('en');
   });
 
-  it('should apply the selected settings on confirm', async () => {
+  it('should apply the selected settings when the buttons row is confirmed', async () => {
     const userPrefs = fixture.debugElement.injector.get<SettingsService<UserPreferences>>(SettingsService<UserPreferences>);
 
-    await component.getInputHandlers().moveRight?.();
-    await component.getInputHandlers().confirm?.();
+    await component.getInputHandlers().moveRight?.(); // change the drafted language
+    await component.getInputHandlers().moveDown?.(); // -> account row
+    await component.getInputHandlers().moveDown?.(); // -> buttons row
+    await component.getInputHandlers().confirm?.(); // Apply is selected by default
 
     expect(userPrefs.get()().lang).toBe('es');
     expect(closeSpy).toHaveBeenCalledWith();
   });
 
-  it('should discard the selected settings on cancel', async () => {
+  it('should discard the selected settings when the buttons row is confirmed on Discard', async () => {
+    const userPrefs = fixture.debugElement.injector.get<SettingsService<UserPreferences>>(SettingsService<UserPreferences>);
+
+    await component.getInputHandlers().moveRight?.();
+    await component.getInputHandlers().moveDown?.();
+    await component.getInputHandlers().moveDown?.();
+    await component.getInputHandlers().moveRight?.(); // switch from Apply to Discard
+    await component.getInputHandlers().confirm?.();
+
+    expect(userPrefs.get()().lang).toBe('en');
+    expect(closeSpy).toHaveBeenCalledWith();
+  });
+
+  it('should discard the drafted settings on cancel, wherever the selection is', async () => {
     const userPrefs = fixture.debugElement.injector.get<SettingsService<UserPreferences>>(SettingsService<UserPreferences>);
 
     await component.getInputHandlers().moveRight?.();
@@ -87,5 +107,59 @@ describe('SettingsComponent', () => {
     const setting = fixture.debugElement.query(By.directive(SettingItemComponent));
 
     expect((setting.nativeElement as HTMLElement).classList).toContain('text-accent-content');
+  });
+
+  // The account row and the buttons row both moved the selection on hover; the setting row did
+  // not, so a mouse could reach every row but that one.
+  it('should move the selection to a setting row on hover', async () => {
+    const setting = fixture.debugElement.query(By.directive(SettingItemComponent)).nativeElement as HTMLElement;
+
+    await component.getInputHandlers().moveDown?.(); // -> account row
+    fixture.detectChanges();
+
+    expect(setting.classList).not.toContain('text-accent-content');
+
+    setting.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(setting.classList).toContain('text-accent-content');
+  });
+
+  it('should open the account view when the account row is confirmed', async () => {
+    await component.getInputHandlers().moveDown?.();
+    await component.getInputHandlers().confirm?.();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.directive(AccountComponent))).toBeTruthy();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return to the settings view when the account view is left', async () => {
+    await component.getInputHandlers().moveDown?.();
+    await component.getInputHandlers().confirm?.();
+    fixture.detectChanges();
+
+    // In the account view, getInputHandlers delegates wholesale — its own cancel emits `back`.
+    await component.getInputHandlers().cancel?.();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.directive(AccountComponent))).toBeFalsy();
+    expect(fixture.debugElement.query(By.directive(SettingItemComponent))).toBeTruthy();
+  });
+
+  // The account view renames the dialog rather than printing a heading of its own. The dialog asks
+  // for the title, so what this owns is the answer — `undefined` leaves the dialog's own in place.
+  it('should offer the account title only while the account view is open', async () => {
+    expect(component.getTitle()).toBeUndefined();
+
+    await component.getInputHandlers().moveDown?.();
+    await component.getInputHandlers().confirm?.();
+    fixture.detectChanges(); // `ah-account` must exist before its handlers can be delegated to
+
+    expect(component.getTitle()).toBe('Your Account');
+
+    await component.getInputHandlers().cancel?.();
+
+    expect(component.getTitle()).toBeUndefined();
   });
 });

--- a/frontend/src/app/shared/ui/components/settings/settings.component.ts
+++ b/frontend/src/app/shared/ui/components/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, linkedSignal, viewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, linkedSignal, signal, viewChild, viewChildren } from '@angular/core';
 import { LangDefinition, TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 import { InputLayer } from '@services/input-manager.service';
 import { listNavigation } from '@services/list-navigation';
@@ -7,11 +7,21 @@ import { provideUserPreferencesService, UserPreferences } from '@services/settin
 import { AH_DIALOG_CONTENT, DialogContent } from '@shared/components/dialog/dialog.content';
 import { AH_DIALOG_CONTEXT } from '@shared/components/dialog/dialog.context';
 import { produce } from 'immer';
+import { AccountComponent } from './account/account.component';
 import { SettingItemComponent } from './setting-item/setting-item.component';
+
+type View = 'settings' | 'account';
+
+type Row = { kind: 'setting'; index: number } | { kind: 'account' } | { kind: 'buttons' };
+
+interface DialogButton {
+  key: 'apply' | 'discard';
+  process: () => void;
+}
 
 @Component({
   selector: 'ah-settings',
-  imports: [SettingItemComponent, TranslocoDirective],
+  imports: [SettingItemComponent, AccountComponent, TranslocoDirective],
   templateUrl: './settings.component.html',
   styles: ``,
   providers: [
@@ -34,9 +44,45 @@ export class SettingsComponent implements DialogContent {
   protected readonly settings = linkedSignal(() => this.userPrefs.get()());
   protected readonly availableLanguages = this.transloco.getAvailableLangs();
 
+  protected readonly view = signal<View>('settings');
+
   private readonly settingsComponents = viewChildren<SettingItemComponent<unknown>>('setting');
-  private readonly navigation = listNavigation({ items: this.settingsComponents });
+  private readonly account = viewChild(AccountComponent);
+
+  protected readonly accountRowIndex = computed(() => this.settingsComponents().length);
+  protected readonly buttonsRowIndex = computed(() => this.settingsComponents().length + 1);
+
+  private readonly rows = computed<Row[]>(() => [
+    ...this.settingsComponents().map((_, index) => ({ kind: 'setting' as const, index })),
+    { kind: 'account' as const },
+    { kind: 'buttons' as const },
+  ]);
+  private readonly navigation = listNavigation({ items: this.rows });
   protected readonly selectedIndex = this.navigation.selectedIndex;
+
+  private readonly buttons = signal<DialogButton[]>([
+    {
+      key: 'apply',
+      process: () => {
+        this.applySettings();
+      },
+    },
+    {
+      key: 'discard',
+      process: () => {
+        this.discardSettings();
+      },
+    },
+  ]);
+  private readonly buttonsNavigation = listNavigation({
+    items: this.buttons,
+    onConfirm: button => {
+      button.process();
+    },
+    orientation: 'horizontal',
+  });
+  protected readonly selectedButtonIndex = this.buttonsNavigation.selectedIndex;
+  protected readonly isButtonsRowSelected = computed(() => this.rows()[this.selectedIndex()]?.kind === 'buttons');
 
   constructor() {
     effect(() => {
@@ -45,19 +91,37 @@ export class SettingsComponent implements DialogContent {
   }
 
   public onOpened = () => {
+    this.view.set('settings');
     this.selectedIndex.set(0);
   };
 
+  /**
+   * The account view renames the dialog rather than printing a heading of its own, which would sit
+   * under a "Settings" title that no longer describes it. `undefined` leaves the dialog's own title
+   * in place, so the settings view needs no key here.
+   */
+  public getTitle = () => (this.view() === 'account' ? this.transloco.translate('settings.account.title') : undefined);
+
   public getInputHandlers: () => InputLayer = () => {
+    if (this.view() === 'account') {
+      return this.account()?.getInputHandlers() ?? {};
+    }
+
+    const row = this.rows()[this.selectedIndex()];
     return {
       ...this.navigation.handlers,
       cancel: this.discardSettings.bind(this),
-      confirm: this.applySettings.bind(this),
       moveLeft: () => {
-        this.settingsComponents()[this.selectedIndex()]?.prevValue.emit();
+        if (row?.kind === 'buttons') this.buttonsNavigation.movePrevious();
+        else if (row?.kind === 'setting') this.settingsComponents()[row.index]?.prevValue.emit();
       },
       moveRight: () => {
-        this.settingsComponents()[this.selectedIndex()]?.nextValue.emit();
+        if (row?.kind === 'buttons') this.buttonsNavigation.moveNext();
+        else if (row?.kind === 'setting') this.settingsComponents()[row.index]?.nextValue.emit();
+      },
+      confirm: () => {
+        if (row?.kind === 'account') this.view.set('account');
+        else if (row?.kind === 'buttons') void this.buttonsNavigation.handlers.confirm?.();
       },
     };
   };

--- a/frontend/src/app/shared/ui/components/sign-in/sign-in.component.html
+++ b/frontend/src/app/shared/ui/components/sign-in/sign-in.component.html
@@ -26,46 +26,19 @@
         </button>
       }
     </div>
-  } @else {
-    <fieldset class="fieldset">
-      <legend class="fieldset-legend">{{ t("credentials.legend") }}</legend>
-
-      <label class="floating-label mt-2">
-        <input type="email" class="validator input w-full" ahFocusTrap required [value]="email()" [disabled]="busy()" (input)="onEmailInput($event)" />
-        <span>{{ t("credentials.email") }}</span>
-      </label>
-
-      <label class="floating-label mt-4">
-        <input type="text" class="input w-full" required [value]="username()" [disabled]="busy()" (input)="onUsernameInput($event)" />
-        <span>{{ t("credentials.username") }}</span>
-      </label>
-
-      <label class="floating-label mt-4">
-        <input type="password" class="input w-full" required [value]="password()" [disabled]="busy()" (input)="onPasswordInput($event)" />
-        <span>{{ t("credentials.password") }}</span>
-      </label>
-    </fieldset>
 
     @if (error(); as err) {
-      <div role="alert" class="mt-4 alert alert-soft alert-error">
-        @if (err.kind === "key") {
-          <span>{{ t(err.key) }}</span>
-        } @else {
-          <span>{{ err.message }}</span>
-        }
-      </div>
+      <ng-container *transloco="let te; prefix: 'auth.credentials_form.errors'">
+        <div role="alert" class="mt-4 alert alert-soft alert-error">
+          @if (err.kind === "key") {
+            <span>{{ te(err.key) }}</span>
+          } @else {
+            <span>{{ err.message }}</span>
+          }
+        </div>
+      </ng-container>
     }
-
-    <div class="mt-6 flex items-center justify-around gap-4">
-      <button type="button" class="btn btn-primary" [disabled]="busy()" (click)="submit()">
-        @if (busy()) {
-          <span class="loading loading-sm loading-spinner"></span>
-        }
-        {{ t("credentials.submit") }}
-      </button>
-      <button type="button" class="btn btn-active" [disabled]="busy()" (click)="backToChoice()">
-        {{ t("credentials.back") }}
-      </button>
-    </div>
+  } @else {
+    <ah-credentials-form dismissKey="back" (result)="onFormResult($event)" />
   }
 </ng-container>

--- a/frontend/src/app/shared/ui/components/sign-in/sign-in.component.spec.ts
+++ b/frontend/src/app/shared/ui/components/sign-in/sign-in.component.spec.ts
@@ -29,6 +29,12 @@ describe('SignInComponent', () => {
     fixture.detectChanges();
   };
 
+  const fillValidCredentials = () => {
+    setInputValue('email', 'a@example.com');
+    setInputValue('text', 'a');
+    setInputValue('password', 'P@ssw0rd');
+  };
+
   beforeEach(async () => {
     loginAnonymously$ = new Subject<User>();
     signIn$ = new Subject<User>();
@@ -62,60 +68,52 @@ describe('SignInComponent', () => {
     });
 
     click('anonymous');
-    loginAnonymously$.next({ isAnonymous: true, email: null });
+    loginAnonymously$.next({ isAnonymous: true, email: null, userName: 'anon-guid' });
 
-    expect(emitted).toEqual([{ isAnonymous: true, email: null } satisfies User]);
+    expect(emitted).toEqual([{ isAnonymous: true, email: null, userName: 'anon-guid' } satisfies User]);
   });
 
-  it('should emit a User when submitting valid credentials', () => {
+  it('should show a translated message in the choice view when travelling light fails', () => {
+    click('anonymous');
+    loginAnonymously$.error(new HttpErrorResponse({ status: 403 }));
+    fixture.detectChanges();
+
+    const alert = fixture.debugElement.query(By.css('.alert')).nativeElement as HTMLElement;
+
+    expect(alert.textContent).toContain('incorrect');
+  });
+
+  it('should render the credentials form when choosing to bind an account', () => {
+    click('credentials');
+
+    expect(fixture.debugElement.query(By.css('.fieldset'))).toBeTruthy();
+  });
+
+  it('should emit a User when the credentials form resolves', async () => {
     const emitted: User[] = [];
     component.result.subscribe(user => {
       emitted.push(user);
     });
 
     click('credentials');
-    setInputValue('email', 'a@example.com');
-    setInputValue('text', 'a');
-    setInputValue('password', 'P@ssw0rd');
+    fillValidCredentials();
     (fixture.debugElement.query(By.css('.btn-primary')).nativeElement as HTMLElement).click();
-    signIn$.next({ isAnonymous: false, email: 'a@example.com' });
+    // The credentials form's own signal-forms submission resolves over a couple of microtasks
+    // beyond the click, and `result.emit` runs once that settles.
+    await fixture.whenStable();
+    signIn$.next({ isAnonymous: false, email: 'a@example.com', userName: 'a' });
+    await fixture.whenStable();
 
-    expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
-    expect(emitted).toEqual([{ isAnonymous: false, email: 'a@example.com' } satisfies User]);
+    expect(emitted).toEqual([{ isAnonymous: false, email: 'a@example.com', userName: 'a' } satisfies User]);
   });
 
-  it('should keep the dialog open with the typed values and show a translated message on 403', () => {
+  it('should go back to the choice view when the credentials form is dismissed', () => {
     click('credentials');
-    setInputValue('email', 'a@example.com');
-    setInputValue('text', 'a');
-    setInputValue('password', 'wrong');
-    (fixture.debugElement.query(By.css('.btn-primary')).nativeElement as HTMLElement).click();
-    signIn$.error(new HttpErrorResponse({ status: 403 }));
+
+    (fixture.debugElement.query(By.css('.btn-active')).nativeElement as HTMLElement).click();
     fixture.detectChanges();
 
-    const alert = fixture.debugElement.query(By.css('.alert')).nativeElement as HTMLElement;
-
-    expect(alert.textContent).toContain('incorrect');
-    expect((fixture.debugElement.query(By.css('input[type=email]')).nativeElement as HTMLInputElement).value).toBe('a@example.com');
-  });
-
-  it('should render IdentityResult descriptions on 400', () => {
-    click('credentials');
-    setInputValue('email', 'a@example.com');
-    setInputValue('text', 'a');
-    setInputValue('password', 'short');
-    (fixture.debugElement.query(By.css('.btn-primary')).nativeElement as HTMLElement).click();
-    signIn$.error(
-      new HttpErrorResponse({
-        status: 400,
-        error: { succeeded: false, errors: [{ code: 'password_short', description: 'Passwords must be at least 6 characters.' }] },
-      }),
-    );
-    fixture.detectChanges();
-
-    const alert = fixture.debugElement.query(By.css('.alert')).nativeElement as HTMLElement;
-
-    expect(alert.textContent).toContain('Passwords must be at least 6 characters.');
+    expect(fixture.debugElement.query(By.css('.fieldset'))).toBeFalsy();
   });
 
   describe('getInputHandlers', () => {
@@ -149,7 +147,7 @@ describe('SignInComponent', () => {
       expect(fixture.debugElement.query(By.css('.fieldset'))).toBeTruthy();
     });
 
-    it('should go back to the choice view on cancel and submit on confirm in the credentials view', async () => {
+    it('should go back to the choice view on cancel, and delegate confirm to the credentials form', async () => {
       click('credentials');
 
       await component.getInputHandlers().cancel?.();
@@ -158,9 +156,10 @@ describe('SignInComponent', () => {
       expect(fixture.debugElement.query(By.css('.fieldset'))).toBeFalsy();
 
       click('credentials');
+      fillValidCredentials();
       await component.getInputHandlers().confirm?.();
 
-      expect(signIn).toHaveBeenCalledWith({ email: '', username: '', password: '' });
+      expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
     });
   });
 
@@ -176,6 +175,14 @@ describe('SignInComponent', () => {
     };
 
     const showsCredentialsView = () => Boolean((dialogFixture.nativeElement as HTMLElement).querySelector('.fieldset'));
+
+    const setDialogInputValue = (type: string, value: string) => {
+      const input = (dialogFixture.nativeElement as HTMLElement).querySelector<HTMLInputElement>(`input[type=${type}]`);
+      if (!input) throw new Error(`No input[type=${type}] found in the dialog`);
+      input.value = value;
+      input.dispatchEvent(new Event('input'));
+      dialogFixture.detectChanges();
+    };
 
     beforeEach(() => {
       dialogFixture = TestBed.createComponent(DialogComponent);
@@ -200,9 +207,13 @@ describe('SignInComponent', () => {
     it('should submit the credentials on Enter rather than re-running the chosen panel', () => {
       expect(showsCredentialsView()).toBe(true);
 
+      setDialogInputValue('email', 'a@example.com');
+      setDialogInputValue('text', 'a');
+      setDialogInputValue('password', 'P@ssw0rd');
+
       press('Enter');
 
-      expect(signIn).toHaveBeenCalledWith({ email: '', username: '', password: '' });
+      expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
       expect(loginAnonymously).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/app/shared/ui/components/sign-in/sign-in.component.ts
+++ b/frontend/src/app/shared/ui/components/sign-in/sign-in.component.ts
@@ -1,13 +1,13 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, output, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, output, signal, Signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslocoDirective } from '@jsverse/transloco';
-import { AuthService, Credentials, User } from '@services/auth.service';
+import { AuthService, User } from '@services/auth.service';
 import { DialogContentWithResult, DialogOptions } from '@services/dialog.service';
 import { InputLayer } from '@services/input-manager.service';
 import { listNavigation } from '@services/list-navigation';
+import { CredentialsFormComponent } from '@shared/components/credentials-form/credentials-form.component';
 import { AH_DIALOG_CONTENT } from '@shared/components/dialog/dialog.content';
-import { FocusTrapDirective } from '@shared/directives/focus-trap.directive';
 
 /**
  * Shared by every entry point to the prompt — the main menu's "sign in to continue" and the auth
@@ -37,7 +37,7 @@ interface IdentityResult {
 
 @Component({
   selector: 'ah-sign-in',
-  imports: [TranslocoDirective, FocusTrapDirective],
+  imports: [TranslocoDirective, CredentialsFormComponent],
   templateUrl: './sign-in.component.html',
   providers: [
     {
@@ -59,10 +59,6 @@ export class SignInComponent implements DialogContentWithResult<User> {
   protected readonly view = signal<View>('choice');
   protected readonly busy = signal(false);
   protected readonly error = signal<ErrorMessage | undefined>(undefined);
-
-  protected readonly email = signal('');
-  protected readonly username = signal('');
-  protected readonly password = signal('');
 
   protected readonly choices: Signal<Choice[]> = signal([
     {
@@ -88,16 +84,14 @@ export class SignInComponent implements DialogContentWithResult<User> {
   });
   protected readonly selectedIndex = this.choiceNavigation.selectedIndex;
 
+  /** Only rendered while `view() === 'credentials'`, so this is `undefined` the rest of the time. */
+  private readonly credentialsForm = viewChild(CredentialsFormComponent);
+
   public getInputHandlers: () => InputLayer = () => {
     if (this.view() === 'credentials') {
-      return {
-        cancel: () => {
-          this.backToChoice();
-        },
-        confirm: () => {
-          this.submit();
-        },
-      };
+      // The keyboard path and the button path go through the same submission on the form's own
+      // side, so nothing here restates what "confirm" or "cancel" mean in that view.
+      return this.credentialsForm()?.getInputHandlers() ?? {};
     }
 
     return {
@@ -108,18 +102,6 @@ export class SignInComponent implements DialogContentWithResult<User> {
     };
   };
 
-  protected onEmailInput(event: Event): void {
-    this.email.set((event.target as HTMLInputElement).value);
-  }
-
-  protected onUsernameInput(event: Event): void {
-    this.username.set((event.target as HTMLInputElement).value);
-  }
-
-  protected onPasswordInput(event: Event): void {
-    this.password.set((event.target as HTMLInputElement).value);
-  }
-
   protected showCredentialsForm(): void {
     this.error.set(undefined);
     this.view.set('credentials');
@@ -128,6 +110,16 @@ export class SignInComponent implements DialogContentWithResult<User> {
   protected backToChoice(): void {
     this.error.set(undefined);
     this.view.set('choice');
+  }
+
+  /** `undefined` is a dismissal — back to the choice view, not a failure to report. */
+  protected onFormResult(user: User | undefined): void {
+    if (user === undefined) {
+      this.backToChoice();
+      return;
+    }
+
+    this.result.emit(user);
   }
 
   protected loginAnonymously(): void {
@@ -149,29 +141,9 @@ export class SignInComponent implements DialogContentWithResult<User> {
       });
   }
 
-  protected submit(): void {
-    if (this.busy()) return;
-
-    const credentials: Credentials = { email: this.email(), username: this.username(), password: this.password() };
-    this.busy.set(true);
-    this.error.set(undefined);
-    this.auth
-      .signIn(credentials)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: user => {
-          this.result.emit(user);
-        },
-        error: (err: unknown) => {
-          this.busy.set(false);
-          this.error.set(this.toErrorMessage(err));
-        },
-      });
-  }
-
   private toErrorMessage(err: unknown): ErrorMessage {
     if (err instanceof HttpErrorResponse) {
-      if (err.status === 403) return { kind: 'key', key: 'errors.wrong_password' };
+      if (err.status === 403) return { kind: 'key', key: 'wrong_password' };
 
       if (err.status === 400) {
         const body = err.error as IdentityResult | null;
@@ -180,6 +152,6 @@ export class SignInComponent implements DialogContentWithResult<User> {
       }
     }
 
-    return { kind: 'key', key: 'errors.generic' };
+    return { kind: 'key', key: 'generic' };
   }
 }


### PR DESCRIPTION
Builds the Account section of the settings dialog — the thing `auth.sign_in.later_hint` ("You can sign the register later, from Settings") had been promising with nowhere to deliver it. Since #501 landed the whole auth surface, this is no longer "build a registration form": the credentials form is extracted out of `SignInComponent` so `DialogService` can open it directly, and the account section is built around it. An anonymous user can bind a permanent account, a signed-in user sees who they are and can sign out, and a signed-out user reaches the form without passing through the prompt's "continue without account" offer.

`UserDto` gains `UserName`, deliberately crossing #429's "backend auth endpoints are out of scope" boundary — two of the three account states cannot be rendered without it, and one field on one record did not warrant its own issue.

## Decisions worth knowing

- **The account section is a second *view* of the settings dialog**, reached by confirming a bare "Account" row, rather than an inline block of buttons. Consequently **the settings dialog's `confirm` no longer applies-and-closes**: Apply/Discard became a navigable buttons row, since one key cannot both commit the language draft and activate a focused button.
- **The credentials form is an Angular Signal Form** — `form()` + validators, submission driven by the `formRoot` directive and a `submission.action` handler. First signal form in the codebase, so it sets the pattern. `submitting` / `invalid` / `errors()` replace the hand-rolled `busy` and `error` signals; one `firstValueFrom` sits at the framework boundary because `action` must return a Promise.
- **Sign-out while anonymous confirms first**, through a new reusable `ConfirmDialogService` (`confirm(options): Observable<boolean>`, always yields a decision) rather than an inline two-step. Permanent sign-out does not warn — nothing is deleted.
- **`DialogOptions` gains `bindings`**, so `DialogService` can pass inputs into the content it creates. Uses Angular's own `inputBinding()` rather than a parallel config mechanism.
- **`DialogContent.onOpened` runs *before* the content's first change detection**, so inputs passed as dialog bindings are still unapplied there. Content now reads them in `ngOnInit`; `onOpened` is documented as being for per-open resets of projected content that outlives a single open. This was a live bug — the confirm dialog's default-button selection was silently ignored — and is covered by a test that drives the real `attachContent` → `open()` path.

## Acceptance criteria

- [x] `GET /auth/info` returns `userName`, and the frontend `User` carries it
- [x] The credentials form lives in one component that `DialogService` can open directly; `sign-in.component.html` no longer declares the three fields itself
- [x] The Account section appears in the settings dialog and renders each of the three states
- [x] The anonymous state displays `userName` exactly as the API returns it, and says the account is local to this device
- [x] An anonymous user can open the form from Settings and bind an account
- [x] Closing the form without submitting leaves an anonymous user still signed in and still anonymous
- [x] The permanent state shows the registered name and email and offers sign out, after which `currentUser` is `undefined` without a page reload
- [x] Signing out while anonymous first opens a confirm dialog warning the account will be permanently deleted; cancelling leaves the session untouched
- [x] Signing out while permanent does not warn
- [x] The signed-out state offers sign in, and reaches the credentials form without passing through the choice view
- [x] `403` and `400` responses surface the server's own message, in both hosts of the form
- [x] Stacked dialogs are keyboard-operable while the settings dialog is open beneath them
- [x] Every new string is a Transloco key present in `en.json`, with no capability claimed that the app does not have

## Verification

- `cd backend && dotnet build` → 0 warnings, 0 errors (`TreatWarningsAsErrors`)
- `cd backend && dotnet test` → 26 unit + 7 integration passed
- `cd frontend && npm run ci:all` → ESLint, Stylelint, cspell, Prettier, `tsc` over both tsconfigs, then Vitest: **304/304 tests, 92/92 files**
- `cd frontend && npm run build-storybook` → succeeded, including the three new account-state stories
- Manual pass in a real browser by @rombolshak, which is what surfaced the `onOpened` ordering bug, the settings-row alignment, the dialog heading, and the invisible `btn-active` highlight — all fixed here

`docs/api.md` is updated for the new `GET /auth/info` shape; the sentence claiming there is no `userName` in the response is gone.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account settings with sign-in, account upgrade, and sign-out actions.
  * Added reusable credential forms with validation and localized error messages.
  * Added confirmation dialogs with customizable labels, appearance, and keyboard navigation.
  * User information now includes usernames; anonymous users receive a GUID username.
  * Settings now support account navigation and localized language controls.

* **Documentation**
  * Updated authentication API documentation to describe the new username field.

* **Bug Fixes**
  * Improved dialog titles so they reflect the currently displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->