### PR TITLE
tests: auth flow through real dialog services

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,6 +71,10 @@ The first run downloads two Chromium builds (the full Chrome for Testing plus th
 
 No coverage is collected for this tier — see the coverage-accounting rule above.
 
+**Dialogs opened by `DialogService`:** it appends its own host to `document.body`, outside `canvasElement`, so `within(canvasElement)` cannot see what it opens. A story that needs one opens it for real — from `afterNextRender`, not `ngOnInit`/`ngAfterViewInit` — and queries it with `screen` or a direct `document.querySelectorAll('dialog')`; content that stays in the story's own template keeps `within(canvasElement)` as before. `frontend/src/app/features/settings/account/account.stories.ts` is the worked example.
+
+Opening a dialog for real does **not** by itself justify F1: happy-dom runs `showModal()` and the rest of `DialogService.open()` fine (`dialog.service.spec.ts`), so a story earns its place only with an assertion that needs real layout or real focus, not merely a real dialog.
+
 ### Writing component specs
 
 The pattern used throughout the codebase (`numeric-text.component.spec.ts` is representative):

--- a/frontend/src/app/features/auth/sign-in/sign-in.component.spec.ts
+++ b/frontend/src/app/features/auth/sign-in/sign-in.component.spec.ts
@@ -4,10 +4,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AuthService, User } from '@core/auth/auth.service';
 import { DialogComponent } from '@core/dialog/dialog.component';
+import { DialogService } from '@core/dialog/dialog.service';
 import { getTranslocoModule } from '@testing/transloco.testing';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { vi } from 'vitest';
-import { SignInComponent } from './sign-in.component';
+import { SIGN_IN_DIALOG_OPTIONS, SignInComponent } from './sign-in.component';
 
 describe('SignInComponent', () => {
   let component: SignInComponent;
@@ -215,6 +216,33 @@ describe('SignInComponent', () => {
 
       expect(signIn).toHaveBeenCalledWith({ email: 'a@example.com', username: 'a', password: 'P@ssw0rd' });
       expect(loginAnonymously).not.toHaveBeenCalled();
+    });
+  });
+
+  // Everything above drives `SignInComponent` or its `getInputHandlers()` directly and never asks
+  // whether choosing anonymous actually closes the dialog around it — that teardown lives in
+  // `DialogService.open()`, not in `SignInComponent`, and nothing above goes through it for real.
+  describe('opened through DialogService', () => {
+    afterEach(() => {
+      document.querySelectorAll('dialog').forEach(dialog => {
+        dialog.remove();
+      });
+    });
+
+    it('should close the dialog once anonymous sign-in resolves', () => {
+      loginAnonymously.mockReturnValue(of({ isAnonymous: true, email: null, userName: 'anon-guid' } satisfies User));
+
+      const dialogService = TestBed.inject(DialogService);
+      dialogService.open(SignInComponent, SIGN_IN_DIALOG_OPTIONS).subscribe();
+      TestBed.tick();
+
+      // Scoped to the dialog, not `document.querySelector` alone: the outer `beforeEach` above
+      // also creates a standalone `SignInComponent` fixture with the same `data-testId`, so an
+      // unscoped query would be ambiguous about which "anonymous" button it clicks.
+      document.querySelector('dialog')?.querySelector<HTMLElement>('[data-testId=anonymous]')?.click();
+      TestBed.tick();
+
+      expect(document.querySelector('dialog')).toBeFalsy();
     });
   });
 });

--- a/frontend/src/app/features/settings/account/account.component.spec.ts
+++ b/frontend/src/app/features/settings/account/account.component.spec.ts
@@ -1,8 +1,9 @@
-import { provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AuthService, User } from '@core/auth/auth.service';
 import { ConfirmDialogService } from '@core/dialog/confirm/confirm-dialog.service';
+import { DialogComponent } from '@core/dialog/dialog.component';
 import { DialogService } from '@core/dialog/dialog.service';
 import { CREDENTIALS_DIALOG_OPTIONS, CredentialsFormComponent } from '@features/auth/credentials-form/credentials-form.component';
 import { getTranslocoModule } from '@testing/transloco.testing';
@@ -146,5 +147,97 @@ describe('AccountComponent', () => {
 
       expect(emittedCount).toBe(1);
     });
+  });
+});
+
+@Component({
+  selector: 'ah-account-dialog-test-host',
+  imports: [DialogComponent, AccountComponent],
+  template: `<ah-dialog><ah-account /></ah-dialog>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class AccountDialogHostComponent {
+  public readonly dialog = viewChild.required(DialogComponent);
+}
+
+// The block above mocks `DialogService`/`ConfirmDialogService` down to `{ open: openDialog }`/
+// `{ confirm }` spies — it proves the right *request* is made, but a spy that never opens anything
+// can never show what actually happens once a real dialog does. This block drives the real
+// services instead, each test commented with what it owns that the mocked block above does not.
+describe('AccountComponent through the real DialogService and ConfirmDialogService', () => {
+  let hostFixture: ComponentFixture<AccountDialogHostComponent>;
+  let hostUser$: BehaviorSubject<User | undefined>;
+  let hostLogout: ReturnType<typeof vi.fn>;
+
+  const clickInDocument = (testId: string) => {
+    document.querySelector<HTMLElement>(`[data-testId=${testId}]`)?.click();
+    TestBed.tick();
+  };
+
+  afterEach(() => {
+    document.querySelectorAll('dialog').forEach(dialog => {
+      dialog.remove();
+    });
+  });
+
+  beforeEach(async () => {
+    hostUser$ = new BehaviorSubject<User | undefined>({ isAnonymous: true, email: null, userName: 'guid-123' });
+    hostLogout = vi.fn(() => of(undefined));
+
+    await TestBed.configureTestingModule({
+      imports: [AccountDialogHostComponent, getTranslocoModule()],
+      providers: [provideZonelessChangeDetection(), { provide: AuthService, useValue: { currentUser: hostUser$, logout: hostLogout } }],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(AccountDialogHostComponent);
+    hostFixture.detectChanges();
+    hostFixture.componentInstance.dialog().open();
+    hostFixture.detectChanges();
+  });
+
+  // Owns what the mocked block cannot: that `openCredentialsForm` really stacks a second,
+  // independently-open `DialogService` dialog rather than replacing the one `AccountComponent`
+  // itself is in — the mocked test only sees that `openDialog` was called with the right arguments.
+  // The top-layer paint order (which dialog visually sits over the other) stays at F1 —
+  // `account.stories.ts`'s `UpgradeStacked` — because that needs real layout.
+  it('should open a second, independently-open dialog for the credentials form, leaving the account dialog open', () => {
+    clickInDocument('upgrade');
+
+    const dialogs = Array.from(document.querySelectorAll('dialog'));
+    expect(dialogs).toHaveLength(2);
+
+    const [accountDialog, credentialsDialog] = dialogs;
+    if (!accountDialog || !credentialsDialog) throw new Error('Expected the account dialog and the credentials form to both be open');
+
+    expect(accountDialog.open).toBe(true);
+    expect(credentialsDialog.open).toBe(true);
+    expect(credentialsDialog.querySelector('form')).toBeTruthy();
+    expect(credentialsDialog.querySelector('h1')?.textContent.trim()).toBe('The Binding Rite');
+  });
+
+  // Owns what the mocked block cannot: that confirming the *real* confirm dialog's own button
+  // actually reaches `AuthService.logout` — the mocked test only sees that `confirm` was called
+  // with the right options, never that a real "yes" answer propagates through it.
+  it('should call logout once the real sign-out confirm dialog is confirmed', () => {
+    clickInDocument('sign_out');
+    clickInDocument('confirm');
+
+    expect(hostLogout).toHaveBeenCalledWith();
+  });
+
+  // Owns what the mocked block cannot: that the real confirm dialog actually opens with Cancel
+  // selected (not just that `defaultButton: 'cancel'` was requested), and that confirming through
+  // the real input layer on a freshly opened prompt reaches Cancel, not logout.
+  it('should default the real sign-out confirm dialog to Cancel, and not log out when it is the one confirmed', () => {
+    clickInDocument('sign_out');
+
+    const cancelButton = document.querySelector<HTMLElement>('[data-testId=cancel]');
+    expect(cancelButton?.classList).toContain('btn-accent');
+    expect(cancelButton?.classList).not.toContain('btn-soft');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
+    TestBed.tick();
+
+    expect(hostLogout).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/settings/account/account.component.ts
+++ b/frontend/src/app/features/settings/account/account.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, outpu
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AuthService } from '@core/auth/auth.service';
 import { ConfirmDialogService } from '@core/dialog/confirm/confirm-dialog.service';
+import { AH_DIALOG_CONTENT, DialogContent } from '@core/dialog/dialog-content';
 import { DialogService } from '@core/dialog/dialog.service';
 import { InputLayer } from '@core/input-manager.service';
 import { listNavigation } from '@core/list-navigation';
@@ -20,16 +21,28 @@ interface AccountAction {
 }
 
 /**
- * A view inside the settings dialog, not dialog content of its own — reached by confirming the
- * "Account" row in `SettingsComponent`. Shows who is signed in and offers that state's actions.
+ * Dialog content in its own right — it provides `AH_DIALOG_CONTENT` below, so a dialog holding
+ * `<ah-account>` alone pushes its input handlers the same way any other content does. In the app it
+ * is reached differently: `SettingsComponent` swaps to this view and delegates `getInputHandlers`
+ * to it directly rather than letting `DialogComponent` discover it on its own. That stays safe
+ * alongside the provider here, because `DialogComponent`'s `contentChild(AH_DIALOG_CONTENT)` is a
+ * *content* query and `<ah-account>` sits in `SettingsComponent`'s own view, not in the dialog's
+ * light DOM (`main-menu.component.html` projects only `<ah-settings />`) — content queries never
+ * enter a view, so the dialog still resolves `SettingsComponent` exactly as before.
  */
 @Component({
   selector: 'ah-account',
   imports: [TranslocoDirective],
   templateUrl: './account.component.html',
+  providers: [
+    {
+      provide: AH_DIALOG_CONTENT,
+      useExisting: AccountComponent,
+    },
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccountComponent {
+export class AccountComponent implements DialogContent {
   private readonly auth = inject(AuthService);
   private readonly dialog = inject(DialogService);
   private readonly confirmDialog = inject(ConfirmDialogService);

--- a/frontend/src/app/features/settings/account/account.stories.ts
+++ b/frontend/src/app/features/settings/account/account.stories.ts
@@ -1,34 +1,91 @@
+import { afterNextRender, ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { AuthService, User } from '@core/auth/auth.service';
-import { ConfirmDialogService } from '@core/dialog/confirm/confirm-dialog.service';
 import { DialogComponent } from '@core/dialog/dialog.component';
-import { DialogService } from '@core/dialog/dialog.service';
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { NEVER, of } from 'rxjs';
+import { TranslocoDirective } from '@jsverse/transloco';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { of } from 'rxjs';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { AccountComponent } from './account.component';
 
-const withUser = (user: User | undefined) =>
-  moduleMetadata({
+/**
+ * `DialogService` appends its own host `<div>` to `document.body`, outside the Storybook canvas —
+ * so the dialog it opens (`UpgradeStacked`'s credentials form) cannot be found with
+ * `within(canvasElement)`. That story opens it for real, from `afterNextRender` — never
+ * `ngOnInit`/`ngAfterViewInit`, which would re-enter change detection — and queries it directly
+ * from `document.querySelectorAll('dialog')` rather than the canvas.
+ *
+ * Opening a dialog for real does **not** by itself earn a story a place at this tier: happy-dom
+ * runs `showModal()` and the rest of `DialogService.open()` fine (`dialog.service.spec.ts`), so a
+ * story earns F1 only when its *assertion* needs real layout or real focus — see
+ * `docs/testing.md`'s "Component tests (F1)" section. `UpgradeStacked` stays only for the
+ * top-layer hit test; everything else it used to assert moved to `account.component.spec.ts`.
+ *
+ * `Anonymous`/`Permanent`/`SignedOut` and `AccountKeyboardNavigation` below need none of the
+ * `DialogService` machinery: the first three render the three static states and never interact, so
+ * the older `[isOpen]="true"` projection is enough; `AccountKeyboardNavigation` opens
+ * `AccountDialogHostComponent`'s own dialog locally (`.open()`, not `DialogService`), which is why
+ * it stays inside the canvas.
+ */
+
+/**
+ * `applicationConfig`, not `moduleMetadata`: `moduleMetadata`'s `providers` land as an *element*-
+ * injector override on Storybook's own wrapper component, which only reaches content declared
+ * inside the story's template. `DialogService.open()` (`UpgradeStacked` below) creates its content
+ * with `createComponent(..., { environmentInjector })` instead, bypassing that element-injector
+ * chain — a stub registered the `moduleMetadata` way would be invisible to it, and the real
+ * `AuthService` would run underneath. `applicationConfig` registers the override on the story's
+ * actual root environment injector, which every path reaches alike.
+ */
+const withUser = (user: User | undefined, logout: ReturnType<typeof fn> = fn(() => of(undefined))) =>
+  applicationConfig({
     providers: [
       {
         provide: AuthService,
-        useValue: { currentUser: of(user) },
+        useValue: { currentUser: of(user), logout },
       },
     ],
   });
+
+const anonymousUser: User = { isAnonymous: true, email: null, userName: '4139f1ea-4901-4253-a391-021faa001677' };
+
+/** Opens `<ah-account>` as its own dialog content — real `showModal()`, so the `AH_DIALOG_CONTENT`
+ * provider `AccountComponent` registers is live and the input layer it pushes actually receives
+ * keydowns, unlike the meta's static `[isOpen]="true"` dialog. */
+@Component({
+  selector: 'ah-story-account-dialog-host',
+  imports: [DialogComponent, AccountComponent, TranslocoDirective],
+  template: ` <ah-dialog *transloco="let t" #dialog size="s" [title]="t('settings.account.title')">
+    <ah-account />
+  </ah-dialog>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class AccountDialogHostComponent {
+  private readonly dialogRef = viewChild.required<DialogComponent>('dialog');
+
+  constructor() {
+    afterNextRender(() => {
+      this.dialogRef().open();
+    });
+  }
+}
 
 const meta: Meta<AccountComponent> = {
   component: AccountComponent,
   decorators: [
     moduleMetadata({
-      imports: [DialogComponent],
-      providers: [
-        // Requests never resolve — the stories only exercise the three static states, not a real
-        // sign-out or upgrade.
-        { provide: DialogService, useValue: { open: () => NEVER } },
-        { provide: ConfirmDialogService, useValue: { confirm: () => NEVER } },
-      ],
+      imports: [DialogComponent, AccountDialogHostComponent],
     }),
   ],
+  // Load-bearing, not just a failure guard: `UpgradeStacked` never closes the credentials dialog it
+  // opens, so on every green run it leaves a `DialogService`-opened dialog in `document.body`,
+  // outside the canvas Storybook replaces between stories. Without this, the next story in this
+  // file would find that stray dialog too. All stories in this file share one browser page.
+  beforeEach: ({ canvasElement }) => {
+    document.body.querySelectorAll('dialog').forEach(dialog => {
+      if (canvasElement.contains(dialog)) return;
+      dialog.parentElement?.remove();
+    });
+  },
   parameters: {
     // The dialog is `position: fixed` and covers the canvas, so story padding would only mislead —
     // this view renders inside the settings dialog's own `size="s"` box, as it does in the app.
@@ -57,4 +114,62 @@ export const Permanent: Story = {
 
 export const SignedOut: Story = {
   decorators: [withUser(undefined)],
+};
+
+export const UpgradeStacked: Story = {
+  decorators: [withUser(anonymousUser)],
+  render: () => ({ template: '<ah-story-account-dialog-host />' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId('upgrade'));
+
+    const credentialsDialog = await waitFor(() => {
+      const dialog = Array.from(document.querySelectorAll('dialog')).find(d => !canvasElement.contains(d));
+      if (!dialog) throw new Error('Expected the credentials form dialog to have opened outside the canvas');
+      return dialog;
+    });
+
+    // Both dialogs being present and `.open`, the form, and its own heading are all covered at F0
+    // now (`account.component.spec.ts`'s "should open a second, independently-open dialog..."), so
+    // under Rule 2 they would be misplaced here. What only a real layout engine can show is "over",
+    // not just "also open": a real top-layer hit test at the credentials dialog's own centre point
+    // has to land inside it, not fall through to the account dialog underneath. Guarded against a
+    // zero-sized rect so this cannot pass vacuously on an unlaid-out element — that is exactly how
+    // it would silently succeed in a fake DOM.
+    const rect = credentialsDialog.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) throw new Error('Expected the credentials dialog to have a laid-out size');
+    const topElement = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+    await expect(credentialsDialog.contains(topElement)).toBe(true);
+  },
+};
+
+export const AccountKeyboardNavigation: Story = {
+  decorators: [withUser(anonymousUser)],
+  render: () => ({ template: '<ah-story-account-dialog-host />' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dialogElement = canvasElement.querySelector('dialog');
+    if (!dialogElement) throw new Error('Expected the account dialog to be in the canvas');
+
+    // `listNavigation` (`core/list-navigation.ts`) only moves a `selectedIndex` signal and never
+    // calls `focus()` — docs/testing.md names that as correctly staying at the happy-dom tier. What
+    // this story can newly observe is what only a real `showModal()` provides: native focus landing
+    // inside the dialog, and a real `keydown` reaching `AccountComponent` through the input layer
+    // that `DialogComponent.open()` pushes (nothing pushes it for `[isOpen]="true"`). Selection
+    // moving between actions below is the visible consequence of that layer receiving the event,
+    // not the claim under test.
+    await expect(dialogElement.contains(document.activeElement)).toBe(true);
+
+    const upgrade = canvas.getByTestId('upgrade');
+    const signOut = canvas.getByTestId('sign_out');
+    await expect(upgrade).toHaveClass('btn-primary');
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(signOut).toHaveClass('btn-primary');
+    await expect(upgrade).not.toHaveClass('btn-primary');
+
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect(upgrade).toHaveClass('btn-primary');
+    await expect(signOut).not.toHaveClass('btn-primary');
+  },
 };

--- a/frontend/src/app/features/settings/settings.component.spec.ts
+++ b/frontend/src/app/features/settings/settings.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { AuthService } from '@core/auth/auth.service';
 import { AH_DIALOG_CONTEXT } from '@core/dialog/dialog-context';
+import { DialogComponent } from '@core/dialog/dialog.component';
 import { SettingsService } from '@core/settings/settings.service';
 import { getTranslocoModule } from '@testing/transloco.testing';
 import { of } from 'rxjs';
@@ -161,5 +162,60 @@ describe('SettingsComponent', () => {
     await component.getInputHandlers().cancel?.();
 
     expect(component.getTitle()).toBeUndefined();
+  });
+});
+
+@Component({
+  selector: 'ah-settings-dialog-test-host',
+  imports: [DialogComponent, SettingsComponent],
+  template: `<ah-dialog><ah-settings /></ah-dialog>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class SettingsDialogHostComponent {
+  public readonly dialog = viewChild.required(DialogComponent);
+}
+
+// The block above builds `SettingsComponent` with `overrideComponent`, swapping in a mocked
+// `AH_DIALOG_CONTEXT` — that can call `getTitle()` directly, but it can never show that a *real*
+// `DialogComponent` resolves `SettingsComponent` as its `AH_DIALOG_CONTENT` and actually repaints
+// its own rendered heading from it. This is that wiring, for real.
+describe('SettingsComponent projected inside a real DialogComponent', () => {
+  let hostFixture: ComponentFixture<SettingsDialogHostComponent>;
+
+  beforeEach(async () => {
+    localStorage.clear();
+
+    await TestBed.configureTestingModule({
+      imports: [SettingsDialogHostComponent, getTranslocoModule({ translocoConfig: { availableLangs: ['en', 'es'], defaultLang: 'en' } })],
+      providers: [
+        provideZonelessChangeDetection(),
+        // `ah-account` is rendered inside the account view, and needs AuthService to construct.
+        { provide: AuthService, useValue: { currentUser: of({ isAnonymous: true, email: null, userName: 'guid-123' }) } },
+      ],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(SettingsDialogHostComponent);
+    hostFixture.detectChanges();
+    hostFixture.componentInstance.dialog().open();
+    hostFixture.detectChanges();
+  });
+
+  it('should rename the real dialog heading when the account view opens, and restore it when it leaves', async () => {
+    const heading = () => (hostFixture.nativeElement as HTMLElement).querySelector('h1')?.textContent.trim();
+    const initialTitle = heading();
+
+    const settings = hostFixture.debugElement.query(By.directive(SettingsComponent)).componentInstance as SettingsComponent;
+    await settings.getInputHandlers().moveDown?.();
+    await settings.getInputHandlers().confirm?.();
+    hostFixture.detectChanges();
+
+    expect((hostFixture.nativeElement as HTMLElement).querySelector('[data-testId=upgrade]')).toBeTruthy();
+    expect(heading()).toBe('Your Account');
+    expect(heading()).not.toBe(initialTitle);
+
+    await settings.getInputHandlers().cancel?.();
+    hostFixture.detectChanges();
+
+    expect(heading()).toBe(initialTitle);
   });
 });


### PR DESCRIPTION
Adds the auth journey's dialog assertions, driven through the **real** `DialogService` and `ConfirmDialogService` rather than the spies that previously sat at those seams. Nothing before this proved that a real "yes" answer from a real confirm dialog propagates back to `AuthService.logout` — the mocked tests only ever saw that the right *request* was made. `AccountComponent` also gains an `AH_DIALOG_CONTENT` provider so a dialog holding it alone picks up its input handlers; this is inert in the app, because the dialog's content query stops at `<ah-settings />` and `<ah-account>` lives in `SettingsComponent`'s view.

## Deviation from the issue: tier placement

The issue specifies all five interactions as component-tier (F1) work, on the premise that they are "five interactions that no happy-dom spec can reach." That premise is wrong for four of them, and the diff follows Rule 2 of `docs/testing.md` instead.

happy-dom runs `showModal()` and the rest of `DialogService.open()` perfectly well — `dialog.service.spec.ts:48-78` already relied on that, asserting both `dialog.open === true` and the dialog's removal from `document.body`. `confirm-dialog.component.spec.ts:97-137` already asserted the same `btn-accent`/`btn-soft` classes. And `input-manager.service.ts:51` listens on `DOCUMENT`, not on a focused element, so keyboard routing needs no real focus at all.

The actual blocker was never a browser capability: it was that the existing stories used `[isOpen]="true"`, which sets an attribute and never calls `DialogComponent.open()` — the method that pushes the input layer. Once a test calls `open()`, happy-dom is sufficient.

So four assertions land at F0, and only two stay at F1 — the two that genuinely need Chromium:

| Assertion | Tier | Home |
| --- | --- | --- |
| Sign-in choice closes the dialog | F0 | `sign-in.component.spec.ts` |
| Settings → Account swaps view **and renames the dialog** | F0 | `settings.component.spec.ts` |
| Upgrade adds a second dialog without replacing the first | F0 | `account.component.spec.ts` |
| Upgrade's form is painted **over** it (top-layer hit test) | **F1** | `account.stories.ts` |
| Anonymous sign-out: confirm → `logout` | F0 | `account.component.spec.ts` |
| Anonymous sign-out: Enter on default Cancel → no `logout` | F0 | `account.component.spec.ts` |
| Real focus inside the dialog after `showModal()` | **F1** | `account.stories.ts` |

No coverage was lost in the move — every assertion was ported to a happy-dom spec before its story was removed, and each was inverted once to confirm it fails at its new tier rather than passing vacuously.

`docs/testing.md` records the trap that caused this, so the next person doesn't repeat it: opening a dialog for real does not by itself justify F1.

## Acceptance criteria

- [x] Choosing an option in the sign-in dialog is asserted to close it — F0
- [x] Confirming "Account" in settings is asserted to show the account view with its own title — F0, asserting the dialog's real `<h1>`, not a hardcoded story title
- [x] "Upgrade" is asserted to open the credentials form over the settings dialog, not in place of it — "not in place of" at F0, "over" at F1 via `document.elementFromPoint`
- [x] Confirming anonymous sign-out reaches `AuthService.logout`; dismissing it does not — F0, through the real confirm dialog
- [x] The anonymous sign-out confirmation is asserted to default to Cancel — F0, both the selected class and behaviourally: Enter on a freshly opened prompt does not delete the account
- [x] Keyboard navigation across the account view's actions moves real focus — asserts native focus landing inside the dialog after `showModal()`. `listNavigation` moves a `selectedIndex` signal and never calls `focus()`; `docs/testing.md` names that as correctly staying at F0, so selection movement is the observable consequence, not the claim
- [x] No assertion duplicates `account.stories.ts`'s three rendered states — `Anonymous`/`Permanent`/`SignedOut` are untouched
- [x] Every new story has a Transloco-backed label path, not a hardcoded English string — the two surviving stories assert no text at all; the demoted specs follow the existing spec convention (`settings.component.spec.ts:159` predates this branch)
- [x] The chosen approach to service-opened dialogs is recorded in a comment where the next person will find it — `account.stories.ts`, plus `docs/testing.md` §Component tests (F1)

## Verification

```
npm test                  # 92 files / 317 tests  (was 312 — grew by the 5 demoted assertions)
npm run test:component    # 42 files / 156 tests  (was 43/160 — shrank by the 4 removed stories)
npm run build-storybook   # succeeded — the only thing that typechecks .stories.ts
npm run lint:all          # clean (one pre-existing, deliberate depcruise warning)
```

Every new F0 test and both surviving F1 stories were inverted once, confirmed to fail, and reverted.

## Known issue, not addressed here

`main-menu.component.html:7` binds the settings dialog title to `t('settings')`, but `en.settings` is an object rather than a string, so that title cannot resolve. Pre-existing and out of scope for #566 — wants its own issue.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
